### PR TITLE
fix(tests): update _formatReplyTo expectation for cross-chat fields

### DIFF
--- a/tests/tdlib-client.test.js
+++ b/tests/tdlib-client.test.js
@@ -123,6 +123,6 @@ describe('_formatReplyTo', () => {
       },
     };
     const result = await client._formatReplyTo(msg);
-    expect(result).toEqual({ id: 5, sender: { id: null, name: 'TelegramUser' } });
+    expect(result).toEqual({ id: 5, chat_id: -1001, sender: { id: null, name: 'TelegramUser' }, text: '' });
   });
 });


### PR DESCRIPTION
- **fix: support cross-chat replies in _formatReplyTo**
- **fix(tests): update _formatReplyTo expectation for cross-chat fields**
