### PR TITLE
fix: clear edit target highlight after editing

### DIFF
--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -476,6 +476,7 @@ local function input_send()
 		state.reply_to = nil
 		state.edit_target = nil
 		state.sending = false
+		update_input_border()
 		return
 	end
 	local function insert_msg(msg)

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -466,9 +466,9 @@ local function input_send()
 	end
 	if state.input_mode == "edit" and state.edit_target then
 		local target = state.edit_target
-		if server.edit_message(state.chat_id, target.id, text) then
+		local ok = server.edit_message(state.chat_id, target.id, text)
+		if ok then
 			target.text = text
-			render()
 			vim.notify("Message edited", vim.log.levels.INFO, { title = "tg" })
 		end
 		state.editor:clear()
@@ -476,6 +476,7 @@ local function input_send()
 		state.reply_to = nil
 		state.edit_target = nil
 		state.sending = false
+		render()
 		update_input_border()
 		return
 	end

--- a/src/server.ts
+++ b/src/server.ts
@@ -207,7 +207,7 @@ app.post('/editMessage', async (req, res) => {
       res.status(400).json({ error: 'chatId, messageId and text are required' });
       return;
     }
-    const result = await tgClient.editMessage(chatId, messageId, text);
+    const result = await tgClient.editMessage(Number(chatId), Number(messageId), text);
     res.json(result);
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });


### PR DESCRIPTION
- **refactor: migrate from JS to TypeScript**
- **refactor: split tdlib-client into modules per TS conventions**
- **docs: add FAQ entry about TypeScript migration**
- **chore: convert bin/tg-ws-helper.js to .ts**
- **fix: update ws.lua helper path to .ts and fix helper imports**
- **docs: mention TypeScript in README**
- **fix: ensure chatId/messageId are numbers in editMessage endpoint**
- **fix: update input border after edit to clear editing indicator**
- **fix: clear edit target highlight after editing**
