### PR TITLE
feat: add missing TDLib update handlers (message edits, deletions, group list, unread)

### DIFF
--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -256,6 +256,67 @@ local function finish_init()
 					end
 				end)
 			end
+		elseif msg.event == "messageContentUpdated" then
+			if msg.chat_id == ui.state.chat_id then
+				vim.schedule(function()
+					for _, m in ipairs(ui.state.messages) do
+						if m.id == msg.message_id then
+							m.text = msg.text or ""
+							m.type = msg.type or m.type
+							ui.render()
+							break
+						end
+					end
+				end)
+			end
+		elseif msg.event == "messagesDeleted" then
+			if msg.chat_id == ui.state.chat_id then
+				vim.schedule(function()
+					local ids = {}
+					for _, id in ipairs(msg.message_ids) do
+						ids[tostring(id)] = true
+					end
+					local i = 1
+					while i <= #ui.state.messages do
+						if ids[tostring(ui.state.messages[i].id)] then
+							table.remove(ui.state.messages, i)
+						else
+							i = i + 1
+						end
+					end
+					ui.render()
+				end)
+			end
+		elseif msg.event == "chatLastMessageUpdated" then
+			vim.schedule(function()
+				if msg.chat_id and ui.state.groups[msg.chat_id] then
+					local g = ui.state.groups[msg.chat_id]
+					if msg.last_message then
+						local lm = msg.last_message
+						local sender = lm.sender and lm.sender.name or "?"
+						g.last_msg = ("[%s] %s: %s"):format(
+							os.date("%Y-%m-%d %H:%M", lm.date),
+							sender,
+							(lm.text or ""):gsub("\n", " "):sub(1, 40)
+						)
+					else
+						g.last_msg = nil
+					end
+					ui.update_title()
+				end
+			end)
+		elseif msg.event == "chatReadInbox" then
+			vim.schedule(function()
+				if msg.chat_id and ui.state.groups[msg.chat_id] then
+					ui.state.groups[msg.chat_id].unread_count = msg.unread_count or 0
+					if msg.chat_id == ui.state.chat_id then
+						ui.state.unread = msg.unread_count or 0
+						ui.update_title()
+					end
+				end
+			end)
+		elseif msg.event == "chatUnreadMentionCount" then
+			-- no UI for mention count yet
 		end
 	end)
 	initialized = true

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,6 +51,7 @@ export class TelegramLSPClient {
       this.resolver,
       this._chats,
       () => global.broadcast,
+      (q) => this.client.invoke(q),
     );
   }
 

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -1,4 +1,5 @@
-import type { TdUpdate, RawTdMessage, RawTdChat, BroadcastFn } from './types';
+import type { TdUpdate, RawTdMessage, RawTdChat, FormattedMessage, BroadcastFn } from './types';
+import { extractText } from './format';
 import type { MessageFormatter } from './format';
 import type { Resolver } from './resolve';
 
@@ -8,6 +9,7 @@ export class UpdateDispatcher {
     private resolver: Resolver,
     private chats: Map<number, RawTdChat>,
     private getBroadcast: () => BroadcastFn | undefined,
+    private invoke: (q: unknown) => Promise<unknown>,
   ) {}
 
   listen(tdClient: { on: (event: string, handler: (update: TdUpdate) => void) => void }) {
@@ -33,6 +35,21 @@ export class UpdateDispatcher {
           break;
         case 'updateChatMember':
           await this.handleChatMemberUpdate(update);
+          break;
+        case 'updateMessageContent':
+          await this.handleMessageContentUpdate(update);
+          break;
+        case 'updateDeleteMessages':
+          await this.handleDeleteMessages(update);
+          break;
+        case 'updateChatLastMessage':
+          await this.handleChatLastMessage(update);
+          break;
+        case 'updateChatReadInbox':
+          this.handleChatReadInbox(update);
+          break;
+        case 'updateChatUnreadMentionCount':
+          this.handleChatUnreadMentionCount(update);
           break;
         default:
           console.log(update);
@@ -124,6 +141,79 @@ export class UpdateDispatcher {
       actor: { id: actorUserId, name: actorName },
       old_status: update.old_status,
       new_status: update.new_status,
+    });
+  }
+
+  async handleMessageContentUpdate(update: TdUpdate) {
+    const broadcast = this.getBroadcast();
+    if (typeof broadcast !== 'function') return;
+    const chatId = update.chat_id!;
+    const messageId = update.message_id as number;
+    if (!chatId || !messageId) return;
+    const newContent = update.new_content as { _: string; text?: { text: string }; caption?: { text: string } } | undefined;
+    if (!newContent) return;
+    const chat = this.chats.get(chatId);
+    broadcast({
+      event: 'messageContentUpdated',
+      chat_id: chatId,
+      message_id: messageId,
+      chat_title: chat ? chat.title : 'Unknown',
+      text: extractText(newContent),
+      type: newContent._,
+    });
+  }
+
+  async handleDeleteMessages(update: TdUpdate) {
+    const broadcast = this.getBroadcast();
+    if (typeof broadcast !== 'function') return;
+    const chatId = update.chat_id!;
+    const messageIds = update.message_ids as number[];
+    if (!chatId || !messageIds) return;
+    broadcast({
+      event: 'messagesDeleted',
+      chat_id: chatId,
+      message_ids: messageIds,
+      is_permanent: update.is_permanent,
+    });
+  }
+
+  async handleChatLastMessage(update: TdUpdate) {
+    const broadcast = this.getBroadcast();
+    if (typeof broadcast !== 'function') return;
+    const chatId = update.chat_id!;
+    if (!chatId) return;
+    const rawMsg = update.last_message as RawTdMessage | null;
+    const chat = this.chats.get(chatId);
+    let formatted = null as FormattedMessage | null;
+    if (rawMsg) {
+      formatted = await this.formatter.format(rawMsg);
+    }
+    broadcast({
+      event: 'chatLastMessageUpdated',
+      chat_id: chatId,
+      chat_title: chat ? chat.title : 'Unknown',
+      last_message: formatted,
+    });
+  }
+
+  handleChatReadInbox(update: TdUpdate) {
+    const broadcast = this.getBroadcast();
+    if (typeof broadcast !== 'function') return;
+    broadcast({
+      event: 'chatReadInbox',
+      chat_id: update.chat_id,
+      last_read_inbox_message_id: update.last_read_inbox_message_id,
+      unread_count: update.unread_count,
+    });
+  }
+
+  handleChatUnreadMentionCount(update: TdUpdate) {
+    const broadcast = this.getBroadcast();
+    if (typeof broadcast !== 'function') return;
+    broadcast({
+      event: 'chatUnreadMentionCount',
+      chat_id: update.chat_id,
+      unread_mention_count: update.unread_mention_count,
     });
   }
 }


### PR DESCRIPTION
## Summary

Added 5 missing TDLib `update*` event handlers that were previously
silently swallowed by the `default: console.log(update)` fallback:

### Backend (`src/updates.ts`)
- **`updateMessageContent`** → broadcasts `messageContentUpdated` with
  new text/type when another client edits a message
- **`updateDeleteMessages`** → broadcasts `messagesDeleted` with
  message_ids so deleted messages are removed from the UI
- **`updateChatLastMessage`** → broadcasts `chatLastMessageUpdated`
  so the group list sidebar reflects the latest message
- **`updateChatReadInbox`** → broadcasts `chatReadInbox` with
  unread_count for real-time badge sync
- **`updateChatUnreadMentionCount`** → broadcasts
  `chatUnreadMentionCount` (handled as no-op, reserved for future)

### Lua frontend (`lua/telegram/init.lua`)
Handles all 5 new WebSocket events:
- `messageContentUpdated` → updates text/type in `state.messages`,
  triggers re-render
- `messagesDeleted` → removes messages by ID from state, re-renders
- `chatLastMessageUpdated` → updates group's last_msg in title bar
- `chatReadInbox` → syncs unread_count on badge and title

Closes #59, #60, #72, #76