### PR TITLE
fix: add console.warn to silent catch blocks

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -189,7 +189,7 @@ export class TelegramLSPClient {
         const info: any = await this.client.invoke({ _: 'getBasicGroupFullInfo', basic_group_id: chat.type.basic_group_id });
         group.description = info.description;
       }
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('_enrichChatGroup failed:', (e as Error).message); }
 
     return group;
   }
@@ -349,7 +349,7 @@ export class TelegramLSPClient {
         const bg = await this.client.invoke({ _: 'getBasicGroup', basic_group_id: chat.type.basic_group_id }) as { member_count: number };
         memberCount = bg.member_count;
       }
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('getChatInfo member count failed:', (e as Error).message); }
     return {
       id: chat.id,
       title: chat.title,
@@ -368,21 +368,21 @@ export class TelegramLSPClient {
         message_ids: messageId ? [messageId] : [],
         force_read: true,
       });
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('viewMessages failed:', (e as Error).message); }
   }
 
   async openChat(chatId: number) {
     if (!this._ready) return;
     try {
       await this.client.invoke({ _: 'openChat', chat_id: chatId });
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('openChat failed:', (e as Error).message); }
   }
 
   async closeChat(chatId: number) {
     if (!this._ready) return;
     try {
       await this.client.invoke({ _: 'closeChat', chat_id: chatId });
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('closeChat failed:', (e as Error).message); }
   }
 
   async sendChatAction(chatId: number, action: string) {
@@ -393,7 +393,7 @@ export class TelegramLSPClient {
         chat_id: chatId,
         action: { _: action },
       });
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('sendChatAction failed:', (e as Error).message); }
   }
 
   async searchMessages(chatId: number, query: string, limit = 50) {
@@ -603,7 +603,7 @@ export class TelegramLSPClient {
       const formatted = await this.formatter.format(msg);
       if (formatted?.filePath) return { path: formatted.filePath };
       return { path: '' };
-    } catch { return null; }
+    } catch (e) { console.warn('getMessageMedia failed:', (e as Error).message); return null; }
   }
 }
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -163,7 +163,7 @@ export class MessageFormatter {
           replyTo.sender = await this.resolver.resolveSender(orig.sender_id);
         }
       }
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('_formatReplyTo getMessage failed:', (e as Error).message); }
     if (r.chat_id && r.chat_id !== msg.chat_id) {
       replyTo.chat_id = r.chat_id;
     }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -21,7 +21,8 @@ export class Resolver {
       const name = [user.first_name, user.last_name].filter(Boolean).join(' ') || `user_${userId}`;
       this._users.set(userId, name);
       return name;
-    } catch {
+    } catch (e) {
+      console.warn('getUserName failed for', userId, (e as Error).message);
       return `user_${userId}`;
     }
   }


### PR DESCRIPTION
Add logging to 7 empty catch {} blocks across client.ts, resolve.ts, and format.ts so TDLib call failures are visible in server logs. Closes #65.