### PR TITLE
feat: channel support, group management, async search, vim.net.request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ pnpm install
 ├── lua/telegram/          # Neovim Lua frontend
 │   ├── init.lua           # Entry point, message handling, WS routing
 │   ├── ui.lua             # UI rendering (popups, keymaps, virtual scroll)
-│   ├── server.lua         # HTTP client to backend (curl-based, retry)
+│   ├── server.lua         # Async HTTP client (vim.net.request or curl fallback)
 │   ├── ws.lua             # WebSocket client (subprocess, reconnect)
 │   ├── auth.lua           # Authentication flow
 │   ├── config.lua         # Configuration, highlight groups

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Backend powered by TDLib + Node.js (TypeScript), frontend in pure Lua with HTTP 
 - [x] Wake-up safe — messages received after sleep are batched and rendered at once, no Neovim freeze
 - [x] Photo / sticker / video / file inline preview — rendered as `![Photo](/path)` markdown; works with image renderers like `snacks.nvim` image module
 - [x] **Private chats** (direct 1-on-1 messages) — press `c` on a message to open DM with the sender
+- [x] **Channel support** — view channels and their messages; admin tools (member list, change info) shown based on permissions
+- [x] **Group management** — view members, ban/unban, restrict/unrestrict, promote/demote admins, add members
+- [x] **Group settings** — change title/description, set default permissions, leave group, delete history
+- [x] **Invite links** — create, view, and revoke invite links
 
 ### What doesn't work yet
 
@@ -98,18 +102,10 @@ Backend powered by TDLib + Node.js (TypeScript), frontend in pure Lua with HTTP 
 - [ ] **Emoji picker**
 - [ ] **React to messages** (like, heart, etc.)
 - [ ] **Poll, contact, location, dice, game, call display** — fallback shows label, content not interactive
-- [ ] **Pin messages**
+- [ ] **Pin / unpin messages**
 - [ ] **Multi-select messages** for batch operations
-- [ ] **Channel support** — currently filtered out, supergroups only
 - [ ] **Chat folders**
 - [ ] **Pinned chats** section
-- [ ] **Leave group**
-- [ ] **Change group name / description**
-- [ ] **Add / kick / ban members**
-- [ ] **Promote / demote admins**
-- [ ] **View member list**
-- [ ] **Pin / unpin messages**
-- [ ] **Generate invite link**
 - [ ] **Change group photo**
 - [ ] **Voice message** recording and sending
 - [ ] **Inline bots** / bot commands
@@ -245,13 +241,14 @@ Inside the chat window:
 | Key | Action |
 |-----|--------|
 | `?` | Toggle help popup |
-| `i` | Open input editor to send a message |
+| `i` | Open input editor to send a message (only if user has permission — hidden for channel subscribers) |
 | `<CR>` | Reply to message / jump to original (if cursor is on a quote line) |
 | `e` | Edit own message at cursor |
 | `d` | Delete message — prompts Revoke (for everyone) / Delete (for me) |
 | `f` | Forward message to another chat |
 | `c` | Open DM with the sender of the message at cursor |
 | `G` | Refresh messages and jump to bottom |
+| `B` | Ban the sender of the message at cursor |
 | `@` | Open context-aware tool picker |
 
 In the chat picker (`@` → chats):

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -355,41 +355,39 @@ local function finish_init()
 		elseif msg.event == "chatUnreadMentionCount" then
 			-- no UI for mention count yet
 		elseif msg.event == "NewChat" then
-			vim.schedule(function()
-				refresh_groups_list()
-			end)
+			refresh_groups_list()
 		elseif msg.event == "chatMember" then
 			local ns = msg.new_status and msg.new_status._
 			if ns == "chatMemberStatusLeft" or ns == "chatMemberStatusBanned" then
-				vim.schedule(function()
-					local cid = msg.chat_id
-					if not cid then return end
-					local removed = false
-					if ui.state.groups[cid] then
-						ui.state.groups[cid] = nil
-						for i, id in ipairs(ui.state.group_ids) do
-							if id == cid then
-								table.remove(ui.state.group_ids, i)
-								break
+				local cid = msg.chat_id
+				local mid = msg.member and msg.member.id
+				if cid and mid and ui.state.my_user_id and mid == ui.state.my_user_id then
+					vim.schedule(function()
+						if ui.state.groups[cid] then
+							ui.state.groups[cid] = nil
+							for i, id in ipairs(ui.state.group_ids) do
+								if id == cid then
+									table.remove(ui.state.group_ids, i)
+									break
+								end
 							end
 						end
-						removed = true
-					end
-					if ui.state.chat_id == cid then
-						ui.destroy_chat()
-					end
-					if removed then
+						if ui.state.chat_id == cid then
+							ui.destroy_chat()
+						end
 						vim.notify("Removed from " .. (msg.chat_title or "chat"), vim.log.levels.INFO, { title = "tg" })
-					end
-				end)
+					end)
+				else
+					refresh_groups_list()
+				end
 			end
 		elseif msg.event == "ChatPosition" then
 			local pos = msg.position
-			if pos and pos.order == "0" then
+			local order = pos and pos.order
+			if pos and (order == 0 or order == "0") then
 				vim.schedule(function()
 					local cid = msg.chat_id
 					if not cid then return end
-					local removed = false
 					if ui.state.groups[cid] then
 						ui.state.groups[cid] = nil
 						for i, id in ipairs(ui.state.group_ids) do
@@ -398,7 +396,6 @@ local function finish_init()
 								break
 							end
 						end
-						removed = true
 					end
 					if ui.state.chat_id == cid then
 						ui.destroy_chat()

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -224,10 +224,11 @@ local function refresh_groups_list()
 	end
 	refresh_timer = vim.fn.timer_start(500, function()
 		refresh_timer = nil
-		local chats = server.get_chats()
-		if chats then
-			ui.set_groups(chats)
-		end
+		server.get_chats_async(function(chats)
+			if chats then
+				ui.set_groups(chats)
+			end
+		end)
 	end, { ["repeat"] = 1 })
 end
 

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -322,6 +322,22 @@ local function finish_init()
 					end
 				end
 			end)
+		elseif msg.event == "chatTitle" then
+			vim.schedule(function()
+				if msg.chat_id and ui.state.groups[msg.chat_id] then
+					ui.state.groups[msg.chat_id].title = msg.title
+					if msg.chat_id == ui.state.chat_id then
+						ui.state.chat_title = msg.title
+						ui.update_title()
+					end
+				end
+			end)
+		elseif msg.event == "chatPermissions" then
+			vim.schedule(function()
+				if msg.chat_id == ui.state.chat_id then
+					ui.state.default_restricted = msg.default_restricted or false
+				end
+			end)
 		elseif msg.event == "chatUnreadMentionCount" then
 			-- no UI for mention count yet
 		end

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -217,6 +217,20 @@ local function queue_msg(msg)
 	msg_timer = vim.fn.timer_start(100, flush_msg_queue, { ["repeat"] = 1 })
 end
 
+local refresh_timer = nil
+local function refresh_groups_list()
+	if refresh_timer then
+		vim.fn.timer_stop(refresh_timer)
+	end
+	refresh_timer = vim.fn.timer_start(500, function()
+		refresh_timer = nil
+		local chats = server.get_chats()
+		if chats then
+			ui.set_groups(chats)
+		end
+	end, { ["repeat"] = 1 })
+end
+
 local function finish_init()
 	ws.ws_start(function(msg)
 		if msg.event == "newMessage" then
@@ -340,6 +354,57 @@ local function finish_init()
 			end)
 		elseif msg.event == "chatUnreadMentionCount" then
 			-- no UI for mention count yet
+		elseif msg.event == "NewChat" then
+			vim.schedule(function()
+				refresh_groups_list()
+			end)
+		elseif msg.event == "chatMember" then
+			local ns = msg.new_status and msg.new_status._
+			if ns == "chatMemberStatusLeft" or ns == "chatMemberStatusBanned" then
+				vim.schedule(function()
+					local cid = msg.chat_id
+					if not cid then return end
+					local removed = false
+					if ui.state.groups[cid] then
+						ui.state.groups[cid] = nil
+						for i, id in ipairs(ui.state.group_ids) do
+							if id == cid then
+								table.remove(ui.state.group_ids, i)
+								break
+							end
+						end
+						removed = true
+					end
+					if ui.state.chat_id == cid then
+						ui.destroy_chat()
+					end
+					if removed then
+						vim.notify("Removed from " .. (msg.chat_title or "chat"), vim.log.levels.INFO, { title = "tg" })
+					end
+				end)
+			end
+		elseif msg.event == "ChatPosition" then
+			local pos = msg.position
+			if pos and pos.order == "0" then
+				vim.schedule(function()
+					local cid = msg.chat_id
+					if not cid then return end
+					local removed = false
+					if ui.state.groups[cid] then
+						ui.state.groups[cid] = nil
+						for i, id in ipairs(ui.state.group_ids) do
+							if id == cid then
+								table.remove(ui.state.group_ids, i)
+								break
+							end
+						end
+						removed = true
+					end
+					if ui.state.chat_id == cid then
+						ui.destroy_chat()
+					end
+				end)
+			end
 		end
 	end)
 	initialized = true

--- a/lua/telegram/render/init.lua
+++ b/lua/telegram/render/init.lua
@@ -79,7 +79,11 @@ function M.render(msg)
 		local s = msg.sender and msg.sender.name or (msg.own and "You" or "Someone")
 		table.insert(out, "[~] " .. s .. " performed an action at " .. date_str)
 	else
-		table.insert(out, string.format("## %s (%s)", sender, date_str))
+		local header = string.format("## %s (%s)", sender, date_str)
+	if msg.views and msg.views > 0 then
+		header = header .. string.format(" [%d views]", msg.views)
+	end
+	table.insert(out, header)
 
 		if msg.replyTo then
 			local r_sender = msg.replyTo.sender and msg.replyTo.sender.name or "?"

--- a/lua/telegram/render/init.lua
+++ b/lua/telegram/render/init.lua
@@ -80,10 +80,10 @@ function M.render(msg)
 		table.insert(out, "[~] " .. s .. " performed an action at " .. date_str)
 	else
 		local header = string.format("## %s (%s)", sender, date_str)
-	if msg.views and msg.views > 0 then
-		header = header .. string.format(" [%d views]", msg.views)
-	end
-	table.insert(out, header)
+		if msg.views and msg.views > 0 then
+			header = header .. string.format(" [%d views]", msg.views)
+		end
+		table.insert(out, header)
 
 		if msg.replyTo then
 			local r_sender = msg.replyTo.sender and msg.replyTo.sender.name or "?"

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -13,7 +13,6 @@ end
 local server_job = nil
 local server_pid = nil
 local server_owner = false
-local cached_groups = nil
 
 local function base_url()
 	return "http://localhost:" .. http_port()
@@ -296,24 +295,7 @@ end
 
 ---@return table|nil
 function M.get_groups()
-	if not cached_groups then
-		cached_groups = http_get("/groups")
-	end
-	return cached_groups
-end
-
-function M.invalidate_groups()
-	cached_groups = nil
-end
-
----@return table|nil
-function M.refresh_groups()
-	cached_groups = nil
-	return M.get_groups()
-end
-
-function M.clear_groups_cache()
-	cached_groups = nil
+	return http_get("/groups")
 end
 
 ---@param chat_id any

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -123,69 +123,45 @@ local function request_curl(opts, callback)
 	})
 end
 
----@type boolean|nil  true = vim.net works, false = curl-only
-local net_ok = nil
-
-function M.get_transport()
-	return net_ok == nil and "probing" or (net_ok and "vim.net.request" or "curl")
-end
-
 local function request_async(opts, callback)
-	if net_ok == nil then
-		if vim.net and vim.net.request then
-			-- Probe: if callback fires within 2s, use vim.net; else curl forever
-			net_ok = false
-			local timed_out = true
-			vim.fn.timer_start(2000, function()
-				if timed_out then
-					request_curl(opts, callback)
-				end
-			end, { ["repeat"] = 1 })
-			vim.net.request(base_url() .. "/health", { timeout = 2000 }, function(err, body, status)
-				if timed_out then return end
-				timed_out = false
-				if not err and status and status < 400 then
-					net_ok = true
-					vim.schedule(function()
-						vim.notify("tg: using vim.net.request", vim.log.levels.INFO, { title = "tg" })
-					end)
-					request_async(opts, callback)
-				else
-					vim.schedule(function()
-						vim.notify("tg: vim.net.request unavailable, using curl", vim.log.levels.INFO, { title = "tg" })
-					end)
-					request_curl(opts, callback)
-				end
-			end)
-		else
-			net_ok = false
-			request_curl(opts, callback)
-		end
-		return
-	end
-
-	if net_ok then
-		vim.net.request(opts.url, {
+	if vim.net and vim.net.request then
+		local ok2, result = pcall(vim.net.request, opts.url, {
 			method = opts.body and "POST" or "GET",
 			headers = opts.body and { ["Content-Type"] = "application/json" } or nil,
 			body = opts.body,
 			timeout = 15000,
-		}, function(err, body, status)
-			if err then
-				callback(nil, err)
+		}, function(...)
+			local args = { ... }
+			if args[1] then
+				callback(nil, args[1])
 				return
 			end
-			local ok, data = pcall(vim.json.decode, body or "{}")
-			if not ok then
-				callback(nil, "HTTP " .. (status or "?") .. " (body not JSON)")
+			local data, status = args[2], args[3]
+			-- Response may be wrapped: { body = json_string, status = int }
+			if type(data) == "table" and data.body then
+				local ok, d = pcall(vim.json.decode, data.body)
+				if ok then data = d end
+				status = data.status or status
+			end
+			if type(data) == "string" then
+				local ok, d = pcall(vim.json.decode, data)
+				if ok then data = d end
+			end
+			if type(data) ~= "table" then
+				callback(nil, "invalid response: " .. tostring(data))
 				return
 			end
-			if (status or 200) >= 400 or (type(data) == "table" and data.error) then
-				callback(nil, (type(data) == "table" and data.error) or ("HTTP " .. (status or "?")))
+			status = tonumber(status) or 200
+			if status >= 400 or data.error then
+				callback(nil, data.error or ("HTTP " .. tostring(status)))
 				return
 			end
 			callback(data, nil)
 		end)
+		if not ok2 then
+			vim.notify("vim.net.request call failed: " .. tostring(result), vim.log.levels.ERROR, { title = "tg" })
+			request_curl(opts, callback)
+		end
 	else
 		request_curl(opts, callback)
 	end
@@ -478,7 +454,11 @@ function M.get_messages_async(chat_id, limit, before, on_ok, on_err, opts)
 		path = path .. "&beforeDate=" .. opts.before_date
 	end
 	request_async({ url = base_url() .. path }, function(data, err)
-		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+		if err then
+			if on_err then vim.schedule(function() on_err(err) end) end
+		else
+			vim.schedule(function() on_ok(data) end)
+		end
 	end)
 end
 
@@ -495,7 +475,7 @@ function M.get_messages_after_async(chat_id, after_id, limit, on_ok, on_err, opt
 		url = url .. "&afterDate=" .. opts.after_date
 	end
 	request_async({ url = url }, function(data, err)
-		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+		if err then if on_err then vim.schedule(function() on_err(err) end) end else vim.schedule(function() on_ok(data) end) end
 	end)
 end
 
@@ -508,7 +488,7 @@ function M.get_messages_around_async(chat_id, message_id, limit, on_ok, on_err)
 		.. "&limit="
 		.. (limit or 11)
 	request_async({ url = url }, function(data, err)
-		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+		if err then if on_err then vim.schedule(function() on_err(err) end) end else vim.schedule(function() on_ok(data) end) end
 	end)
 end
 

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -620,19 +620,12 @@ function M.set_default_permissions(chat_id, restrict_all)
 		can_send_polls = not restrict_all,
 		can_send_other_messages = not restrict_all,
 		can_add_web_page_previews = not restrict_all,
-		can_change_info = not restrict_all,
-		can_invite_users = not restrict_all,
-		can_pin_messages = not restrict_all,
-		can_manage_topics = not restrict_all,
+		can_change_info = false,
+		can_invite_users = false,
+		can_pin_messages = false,
+		can_manage_topics = false,
 	}
 	return http_post("/chat/set-permissions", { chatId = chat_id, permissions = perms }) ~= nil
-end
-
----@param chat_id any
----@param delay_seconds integer
----@return boolean
-function M.set_slow_mode(chat_id, delay_seconds)
-	return http_post("/chat/set-slow-mode", { chatId = chat_id, delaySeconds = delay_seconds }) ~= nil
 end
 
 -- ─── Group Settings ─────────────────────────────────────────────────────

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -595,14 +595,14 @@ end
 
 ---@param chat_id any
 ---@return table|nil
-function M.get_members(chat_id)
-	return http_get("/chat/members?chatId=" .. chat_id)
+function M.get_my_permissions(chat_id)
+	return http_get("/chat/my-permissions?chatId=" .. chat_id)
 end
 
 ---@param chat_id any
 ---@return table|nil
-function M.get_admins(chat_id)
-	return http_get("/chat/admins?chatId=" .. chat_id)
+function M.get_members(chat_id)
+	return http_get("/chat/members?chatId=" .. chat_id)
 end
 
 ---@param chat_id any

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -312,6 +312,37 @@ function M.search_messages(chat_id, query)
 	return http_get("/searchMessages?chatId=" .. chat_id .. "&query=" .. query:gsub(" ", "+"))
 end
 
+---@param chat_id any
+---@param query string
+---@param on_ok fun(data: table)
+---@param on_err fun()|nil
+function M.search_messages_async(chat_id, query, on_ok, on_err)
+	local url = base_url()
+		.. "/searchMessages?chatId="
+		.. chat_id
+		.. "&query="
+		.. query:gsub(" ", "+")
+	local stdout = {}
+	vim.fn.jobstart({ "curl", "-s", "--connect-timeout", "5", "--max-time", "20", url }, {
+		stdout_buffered = true,
+		on_stdout = function(_, data)
+			stdout = data
+		end,
+		on_exit = function(_, code)
+			if code ~= 0 then
+				if on_err then vim.schedule(on_err) end
+				return
+			end
+			local ok, data = pcall(vim.json.decode, table.concat(stdout))
+			if not ok or not data then
+				if on_err then vim.schedule(on_err) end
+				return
+			end
+			if on_ok then vim.schedule(function() on_ok(data) end) end
+		end,
+	})
+end
+
 function M.get_media(chat_id, message_id)
 	local url = base_url() .. "/messageMedia?chatId=" .. chat_id .. "&messageId=" .. message_id
 	local result = vim.fn.system({ "curl", "-s", "--connect-timeout", "5", "--max-time", "20", url })

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -101,50 +101,93 @@ end
 
 ---@param opts { url: string, body?: string }
 ---@param callback fun(data: table|nil, err: string|nil)
+local function request_curl(opts, callback)
+	local args = { "curl", "-s", "--connect-timeout", "3", "--max-time", "15" }
+	if opts.body then
+		table.insert(args, "-X"); table.insert(args, "POST")
+		table.insert(args, "-H"); table.insert(args, "Content-Type: application/json")
+		table.insert(args, "-d"); table.insert(args, opts.body)
+	end
+	table.insert(args, opts.url)
+	local stdout = {}
+	vim.fn.jobstart(args, {
+		stdout_buffered = true,
+		on_stdout = function(_, data) stdout = data end,
+		on_exit = function(_, code)
+			if code ~= 0 then callback(nil, "curl exit " .. code) return end
+			local ok, data = pcall(vim.json.decode, table.concat(stdout))
+			if not ok then callback(nil, "Invalid JSON response") return end
+			if type(data) == "table" and data.error then callback(nil, data.error) return end
+			callback(data, nil)
+		end,
+	})
+end
+
+---@type boolean|nil  true = vim.net works, false = curl-only
+local net_ok = nil
+
+function M.get_transport()
+	return net_ok == nil and "probing" or (net_ok and "vim.net.request" or "curl")
+end
+
 local function request_async(opts, callback)
-	if vim.net and vim.net.request then
-		vim.net.request({
-			url = opts.url,
+	if net_ok == nil then
+		if vim.net and vim.net.request then
+			-- Probe: if callback fires within 2s, use vim.net; else curl forever
+			net_ok = false
+			local timed_out = true
+			vim.fn.timer_start(2000, function()
+				if timed_out then
+					request_curl(opts, callback)
+				end
+			end, { ["repeat"] = 1 })
+			vim.net.request(base_url() .. "/health", { timeout = 2000 }, function(err, body, status)
+				if timed_out then return end
+				timed_out = false
+				if not err and status and status < 400 then
+					net_ok = true
+					vim.schedule(function()
+						vim.notify("tg: using vim.net.request", vim.log.levels.INFO, { title = "tg" })
+					end)
+					request_async(opts, callback)
+				else
+					vim.schedule(function()
+						vim.notify("tg: vim.net.request unavailable, using curl", vim.log.levels.INFO, { title = "tg" })
+					end)
+					request_curl(opts, callback)
+				end
+			end)
+		else
+			net_ok = false
+			request_curl(opts, callback)
+		end
+		return
+	end
+
+	if net_ok then
+		vim.net.request(opts.url, {
 			method = opts.body and "POST" or "GET",
 			headers = opts.body and { ["Content-Type"] = "application/json" } or nil,
 			body = opts.body,
 			timeout = 15000,
-		}, function(err, response)
+		}, function(err, body, status)
 			if err then
 				callback(nil, err)
 				return
 			end
-			local ok, data = pcall(vim.json.decode, response.body or "{}")
+			local ok, data = pcall(vim.json.decode, body or "{}")
 			if not ok then
-				callback(nil, "Invalid JSON response")
+				callback(nil, "HTTP " .. (status or "?") .. " (body not JSON)")
 				return
 			end
-			if type(data) == "table" and data.error then
-				callback(nil, data.error)
+			if (status or 200) >= 400 or (type(data) == "table" and data.error) then
+				callback(nil, (type(data) == "table" and data.error) or ("HTTP " .. (status or "?")))
 				return
 			end
 			callback(data, nil)
 		end)
 	else
-		local args = { "curl", "-s", "--connect-timeout", "3", "--max-time", "15" }
-		if opts.body then
-			table.insert(args, "-X"); table.insert(args, "POST")
-			table.insert(args, "-H"); table.insert(args, "Content-Type: application/json")
-			table.insert(args, "-d"); table.insert(args, opts.body)
-		end
-		table.insert(args, opts.url)
-		local stdout = {}
-		vim.fn.jobstart(args, {
-			stdout_buffered = true,
-			on_stdout = function(_, data) stdout = data end,
-			on_exit = function(_, code)
-				if code ~= 0 then callback(nil, "curl exit " .. code) return end
-				local ok, data = pcall(vim.json.decode, table.concat(stdout))
-				if not ok then callback(nil, "Invalid JSON response") return end
-				if type(data) == "table" and data.error then callback(nil, data.error) return end
-				callback(data, nil)
-			end,
-		})
+		request_curl(opts, callback)
 	end
 end
 

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -139,9 +139,9 @@ local function request_async(opts, callback)
 			local data, status = args[2], args[3]
 			-- Response may be wrapped: { body = json_string, status = int }
 			if type(data) == "table" and data.body then
+				status = data.status or status
 				local ok, d = pcall(vim.json.decode, data.body)
 				if ok then data = d end
-				status = data.status or status
 			end
 			if type(data) == "string" then
 				local ok, d = pcall(vim.json.decode, data)

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -542,4 +542,151 @@ function M.forward_messages(from_chat_id, message_ids, to_chat_id)
 	return http_post("/forwardMessages", { fromChatId = from_chat_id, messageIds = message_ids, toChatId = to_chat_id })
 end
 
+-- ─── Member Management ─────────────────────────────────────────────────
+
+---@param chat_id any
+---@param user_id any
+---@return boolean
+function M.ban_member(chat_id, user_id)
+	return http_post("/chat/ban", { chatId = chat_id, userId = user_id }) ~= nil
+end
+
+---@param chat_id any
+---@param user_id any
+---@return boolean
+function M.unban_member(chat_id, user_id)
+	return http_post("/chat/unban", { chatId = chat_id, userId = user_id }) ~= nil
+end
+
+---@param chat_id any
+---@param user_id any
+---@return boolean
+function M.promote_member(chat_id, user_id)
+	return http_post("/chat/promote", { chatId = chat_id, userId = user_id }) ~= nil
+end
+
+---@param chat_id any
+---@param user_id any
+---@return boolean
+function M.demote_member(chat_id, user_id)
+	return http_post("/chat/demote", { chatId = chat_id, userId = user_id }) ~= nil
+end
+
+---@param chat_id any
+---@param user_id any
+---@return boolean
+function M.restrict_member(chat_id, user_id)
+	return http_post("/chat/restrict", { chatId = chat_id, userId = user_id }) ~= nil
+end
+
+---@param chat_id any
+---@param user_id any
+---@return boolean
+function M.unrestrict_member(chat_id, user_id)
+	return http_post("/chat/unrestrict", { chatId = chat_id, userId = user_id }) ~= nil
+end
+
+---@param chat_id any
+---@param user_id any
+---@return boolean
+function M.add_member(chat_id, user_id)
+	return http_post("/chat/add-member", { chatId = chat_id, userId = user_id }) ~= nil
+end
+
+---@param chat_id any
+---@return table|nil
+function M.get_members(chat_id)
+	return http_get("/chat/members?chatId=" .. chat_id)
+end
+
+---@param chat_id any
+---@return table|nil
+function M.get_admins(chat_id)
+	return http_get("/chat/admins?chatId=" .. chat_id)
+end
+
+---@param chat_id any
+---@param restrict_all boolean
+---@return boolean
+function M.set_default_permissions(chat_id, restrict_all)
+	local perms = {
+		can_send_messages = not restrict_all,
+		can_send_audios = not restrict_all,
+		can_send_documents = not restrict_all,
+		can_send_photos = not restrict_all,
+		can_send_videos = not restrict_all,
+		can_send_video_notes = not restrict_all,
+		can_send_voice_notes = not restrict_all,
+		can_send_polls = not restrict_all,
+		can_send_other_messages = not restrict_all,
+		can_add_web_page_previews = not restrict_all,
+		can_change_info = not restrict_all,
+		can_invite_users = not restrict_all,
+		can_pin_messages = not restrict_all,
+		can_manage_topics = not restrict_all,
+	}
+	return http_post("/chat/set-permissions", { chatId = chat_id, permissions = perms }) ~= nil
+end
+
+---@param chat_id any
+---@param delay_seconds integer
+---@return boolean
+function M.set_slow_mode(chat_id, delay_seconds)
+	return http_post("/chat/set-slow-mode", { chatId = chat_id, delaySeconds = delay_seconds }) ~= nil
+end
+
+-- ─── Group Settings ─────────────────────────────────────────────────────
+
+---@param chat_id any
+---@param title string
+---@return boolean
+function M.set_chat_title(chat_id, title)
+	return http_post("/chat/set-title", { chatId = chat_id, title = title }) ~= nil
+end
+
+---@param chat_id any
+---@param description string
+---@return boolean
+function M.set_chat_description(chat_id, description)
+	return http_post("/chat/set-description", { chatId = chat_id, description = description }) ~= nil
+end
+
+---@param chat_id any
+---@return boolean
+function M.leave_chat(chat_id)
+	return http_post("/chat/leave", { chatId = chat_id }) ~= nil
+end
+
+---@param chat_id any
+---@return boolean
+function M.delete_chat_history(chat_id)
+	return http_post("/chat/delete-history", { chatId = chat_id }) ~= nil
+end
+
+-- ─── Invite Links ──────────────────────────────────────────────────────
+
+---@param chat_id any
+---@return table|nil
+function M.get_invite_links(chat_id)
+	return http_get("/chat/invite-links?chatId=" .. chat_id)
+end
+
+---@param chat_id any
+---@param expire_date integer|nil
+---@param member_limit integer|nil
+---@return boolean
+function M.create_invite_link(chat_id, expire_date, member_limit)
+	local body = { chatId = chat_id }
+	if expire_date then body.expireDate = expire_date end
+	if member_limit then body.memberLimit = member_limit end
+	return http_post("/chat/create-invite-link", body) ~= nil
+end
+
+---@param chat_id any
+---@param invite_link string
+---@return boolean
+function M.revoke_invite_link(chat_id, invite_link)
+	return http_post("/chat/revoke-invite-link", { chatId = chat_id, inviteLink = invite_link }) ~= nil
+end
+
 return M

--- a/lua/telegram/server.lua
+++ b/lua/telegram/server.lua
@@ -35,7 +35,6 @@ local function curl_with_retry(curl_args)
 		if vim.v.shell_error == 0 then
 			return result
 		end
-		-- Server responded with an error body — persistent, don't retry
 		if result and #result > 0 then
 			local ok, data = pcall(vim.json.decode, result)
 			local err = (ok and type(data) == "table" and data.error) or result
@@ -98,6 +97,55 @@ local function http_post(path, body)
 		return nil
 	end
 	return data
+end
+
+---@param opts { url: string, body?: string }
+---@param callback fun(data: table|nil, err: string|nil)
+local function request_async(opts, callback)
+	if vim.net and vim.net.request then
+		vim.net.request({
+			url = opts.url,
+			method = opts.body and "POST" or "GET",
+			headers = opts.body and { ["Content-Type"] = "application/json" } or nil,
+			body = opts.body,
+			timeout = 15000,
+		}, function(err, response)
+			if err then
+				callback(nil, err)
+				return
+			end
+			local ok, data = pcall(vim.json.decode, response.body or "{}")
+			if not ok then
+				callback(nil, "Invalid JSON response")
+				return
+			end
+			if type(data) == "table" and data.error then
+				callback(nil, data.error)
+				return
+			end
+			callback(data, nil)
+		end)
+	else
+		local args = { "curl", "-s", "--connect-timeout", "3", "--max-time", "15" }
+		if opts.body then
+			table.insert(args, "-X"); table.insert(args, "POST")
+			table.insert(args, "-H"); table.insert(args, "Content-Type: application/json")
+			table.insert(args, "-d"); table.insert(args, opts.body)
+		end
+		table.insert(args, opts.url)
+		local stdout = {}
+		vim.fn.jobstart(args, {
+			stdout_buffered = true,
+			on_stdout = function(_, data) stdout = data end,
+			on_exit = function(_, code)
+				if code ~= 0 then callback(nil, "curl exit " .. code) return end
+				local ok, data = pcall(vim.json.decode, table.concat(stdout))
+				if not ok then callback(nil, "Invalid JSON response") return end
+				if type(data) == "table" and data.error then callback(nil, data.error) return end
+				callback(data, nil)
+			end,
+		})
+	end
 end
 
 ---@return table|nil
@@ -249,6 +297,15 @@ function M.get_chat(chat_id)
 end
 
 ---@param chat_id any
+---@param on_ok fun(data: table)|nil
+---@param on_err fun()|nil
+function M.get_chat_async(chat_id, on_ok, on_err)
+	request_async({ url = base_url() .. "/chat?chatId=" .. chat_id }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
+end
+
+---@param chat_id any
 ---@return boolean
 function M.open_chat(chat_id)
 	return http_post("/chat/open", { chatId = chat_id }) ~= nil
@@ -279,6 +336,14 @@ M.DEFAULT_LIMIT = 50
 ---@return table|nil
 function M.get_chats()
 	return http_get("/chats")
+end
+
+---@param on_ok fun(data: table)|nil
+---@param on_err fun()|nil
+function M.get_chats_async(on_ok, on_err)
+	request_async({ url = base_url() .. "/chats" }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
 end
 
 ---@param username string
@@ -317,30 +382,9 @@ end
 ---@param on_ok fun(data: table)
 ---@param on_err fun()|nil
 function M.search_messages_async(chat_id, query, on_ok, on_err)
-	local url = base_url()
-		.. "/searchMessages?chatId="
-		.. chat_id
-		.. "&query="
-		.. query:gsub(" ", "+")
-	local stdout = {}
-	vim.fn.jobstart({ "curl", "-s", "--connect-timeout", "5", "--max-time", "20", url }, {
-		stdout_buffered = true,
-		on_stdout = function(_, data)
-			stdout = data
-		end,
-		on_exit = function(_, code)
-			if code ~= 0 then
-				if on_err then vim.schedule(on_err) end
-				return
-			end
-			local ok, data = pcall(vim.json.decode, table.concat(stdout))
-			if not ok or not data then
-				if on_err then vim.schedule(on_err) end
-				return
-			end
-			if on_ok then vim.schedule(function() on_ok(data) end) end
-		end,
-	})
+	request_async({ url = base_url() .. "/searchMessages?chatId=" .. chat_id .. "&query=" .. query:gsub(" ", "+") }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
 end
 
 function M.get_media(chat_id, message_id)
@@ -359,26 +403,9 @@ function M.get_media(chat_id, message_id)
 end
 
 function M.get_media_async(chat_id, message_id, on_ok)
-	local url = base_url() .. "/messageMedia?chatId=" .. chat_id .. "&messageId=" .. message_id
-	local stdout = {}
-	vim.fn.jobstart({ "curl", "-s", "--connect-timeout", "5", "--max-time", "20", url }, {
-		stdout_buffered = true,
-		on_stdout = function(_, data)
-			stdout = data
-		end,
-		on_exit = function(_, code)
-			if code ~= 0 or #stdout == 0 then
-				if on_ok then vim.schedule(function() on_ok(nil) end) end
-				return
-			end
-			local ok, data = pcall(vim.json.decode, table.concat(stdout))
-			if not ok or not data then
-				if on_ok then vim.schedule(function() on_ok(nil) end) end
-				return
-			end
-			if on_ok then vim.schedule(function() on_ok(data) end) end
-		end,
-	})
+	request_async({ url = base_url() .. "/messageMedia?chatId=" .. chat_id .. "&messageId=" .. message_id }, function(data, err)
+		vim.schedule(function() on_ok(err and nil or data) end)
+	end)
 end
 
 ---@param chat_id any
@@ -407,34 +434,9 @@ function M.get_messages_async(chat_id, limit, before, on_ok, on_err, opts)
 	if opts.before_date then
 		path = path .. "&beforeDate=" .. opts.before_date
 	end
-	local url = base_url() .. path
-	local stdout = {}
-	vim.fn.jobstart({ "curl", "-s", "--connect-timeout", "3", "--max-time", "15", "--fail-with-body", url }, {
-		stdout_buffered = true,
-		on_stdout = function(_, data)
-			stdout = data
-		end,
-		on_exit = function(_, code)
-			if code ~= 0 then
-				if on_err then
-					vim.schedule(on_err)
-				end
-				return
-			end
-			local ok, data = pcall(vim.json.decode, table.concat(stdout))
-			if not ok or not data then
-				if on_err then
-					vim.schedule(on_err)
-				end
-				return
-			end
-			if on_ok then
-				vim.schedule(function()
-					on_ok(data)
-				end)
-			end
-		end,
-	})
+	request_async({ url = base_url() .. path }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
 end
 
 function M.get_messages_after_async(chat_id, after_id, limit, on_ok, on_err, opts)
@@ -449,33 +451,9 @@ function M.get_messages_after_async(chat_id, after_id, limit, on_ok, on_err, opt
 	if opts.after_date then
 		url = url .. "&afterDate=" .. opts.after_date
 	end
-	local stdout = {}
-	vim.fn.jobstart({ "curl", "-s", "--connect-timeout", "3", "--max-time", "15", "--fail-with-body", url }, {
-		stdout_buffered = true,
-		on_stdout = function(_, data)
-			stdout = data
-		end,
-		on_exit = function(_, code)
-			if code ~= 0 then
-				if on_err then
-					vim.schedule(on_err)
-				end
-				return
-			end
-			local ok, data = pcall(vim.json.decode, table.concat(stdout))
-			if not ok or not data then
-				if on_err then
-					vim.schedule(on_err)
-				end
-				return
-			end
-			if on_ok then
-				vim.schedule(function()
-					on_ok(data)
-				end)
-			end
-		end,
-	})
+	request_async({ url = url }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
 end
 
 function M.get_messages_around_async(chat_id, message_id, limit, on_ok, on_err)
@@ -486,33 +464,9 @@ function M.get_messages_around_async(chat_id, message_id, limit, on_ok, on_err)
 		.. message_id
 		.. "&limit="
 		.. (limit or 11)
-	local stdout = {}
-	vim.fn.jobstart({ "curl", "-s", "--connect-timeout", "3", "--max-time", "15", "--fail-with-body", url }, {
-		stdout_buffered = true,
-		on_stdout = function(_, data)
-			stdout = data
-		end,
-		on_exit = function(_, code)
-			if code ~= 0 then
-				if on_err then
-					vim.schedule(on_err)
-				end
-				return
-			end
-			local ok, data = pcall(vim.json.decode, table.concat(stdout))
-			if not ok or not data then
-				if on_err then
-					vim.schedule(on_err)
-				end
-				return
-			end
-			if on_ok then
-				vim.schedule(function()
-					on_ok(data)
-				end)
-			end
-		end,
-	})
+	request_async({ url = url }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
 end
 
 ---@param chat_id any
@@ -613,9 +567,27 @@ function M.get_my_permissions(chat_id)
 end
 
 ---@param chat_id any
+---@param on_ok fun(data: table)|nil
+---@param on_err fun()|nil
+function M.get_my_permissions_async(chat_id, on_ok, on_err)
+	request_async({ url = base_url() .. "/chat/my-permissions?chatId=" .. chat_id }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
+end
+
+---@param chat_id any
 ---@return table|nil
 function M.get_members(chat_id)
 	return http_get("/chat/members?chatId=" .. chat_id)
+end
+
+---@param chat_id any
+---@param on_ok fun(data: table)|nil
+---@param on_err fun()|nil
+function M.get_members_async(chat_id, on_ok, on_err)
+	request_async({ url = base_url() .. "/chat/members?chatId=" .. chat_id }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
 end
 
 ---@param chat_id any
@@ -675,6 +647,15 @@ end
 ---@return table|nil
 function M.get_invite_links(chat_id)
 	return http_get("/chat/invite-links?chatId=" .. chat_id)
+end
+
+---@param chat_id any
+---@param on_ok fun(data: table)|nil
+---@param on_err fun()|nil
+function M.get_invite_links_async(chat_id, on_ok, on_err)
+	request_async({ url = base_url() .. "/chat/invite-links?chatId=" .. chat_id }, function(data, err)
+		if err then if on_err then vim.schedule(on_err) end else vim.schedule(function() on_ok(data) end) end
+	end)
 end
 
 ---@param chat_id any

--- a/lua/telegram/tools.lua
+++ b/lua/telegram/tools.lua
@@ -175,9 +175,16 @@ M.register("openlink", {
 	end,
 })
 
+local function is_group()
+	local cid = ui.state.chat_id
+	if not cid then return false end
+	local g = ui.state.groups[cid]
+	return g and g.type ~= "private"
+end
+
 M.register("members", {
 	description = "View and manage chat members",
-	condition = function() return ui.state.chat_id ~= nil end,
+	condition = is_group,
 	callback = function()
 		if not ui.state.chat_id then
 			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
@@ -187,21 +194,9 @@ M.register("members", {
 	end,
 })
 
-M.register("admins", {
-	description = "View chat administrators",
-	condition = function() return ui.state.chat_id ~= nil end,
-	callback = function()
-		if not ui.state.chat_id then
-			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
-			return
-		end
-		ui.show_admin_list(ui.state.chat_id)
-	end,
-})
-
 M.register("invitelinks", {
 	description = "Manage invite links",
-	condition = function() return ui.state.chat_id ~= nil end,
+	condition = is_group,
 	callback = function()
 		if not ui.state.chat_id then
 			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
@@ -213,7 +208,7 @@ M.register("invitelinks", {
 
 M.register("groupsettings", {
 	description = "Group settings (title, description, slow mode, etc.)",
-	condition = function() return ui.state.chat_id ~= nil end,
+	condition = is_group,
 	callback = function()
 		if not ui.state.chat_id then
 			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })

--- a/lua/telegram/tools.lua
+++ b/lua/telegram/tools.lua
@@ -209,7 +209,7 @@ M.register("invitelinks", {
 })
 
 M.register("groupsettings", {
-	description = "Group settings (title, description, slow mode, etc.)",
+	description = "Group settings (title, description, permissions, etc.)",
 	condition = is_group,
 	callback = function()
 		if not ui.state.chat_id then

--- a/lua/telegram/tools.lua
+++ b/lua/telegram/tools.lua
@@ -175,6 +175,54 @@ M.register("openlink", {
 	end,
 })
 
+M.register("members", {
+	description = "View and manage chat members",
+	condition = function() return ui.state.chat_id ~= nil end,
+	callback = function()
+		if not ui.state.chat_id then
+			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
+			return
+		end
+		ui.show_member_list(ui.state.chat_id)
+	end,
+})
+
+M.register("admins", {
+	description = "View chat administrators",
+	condition = function() return ui.state.chat_id ~= nil end,
+	callback = function()
+		if not ui.state.chat_id then
+			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
+			return
+		end
+		ui.show_admin_list(ui.state.chat_id)
+	end,
+})
+
+M.register("invitelinks", {
+	description = "Manage invite links",
+	condition = function() return ui.state.chat_id ~= nil end,
+	callback = function()
+		if not ui.state.chat_id then
+			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
+			return
+		end
+		ui.show_invite_links(ui.state.chat_id)
+	end,
+})
+
+M.register("groupsettings", {
+	description = "Group settings (title, description, slow mode, etc.)",
+	condition = function() return ui.state.chat_id ~= nil end,
+	callback = function()
+		if not ui.state.chat_id then
+			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
+			return
+		end
+		ui.show_group_settings(ui.state.chat_id)
+	end,
+})
+
 M.register("refreshmedia", {
 	description = "Download and update image for message under cursor",
 	condition = function()

--- a/lua/telegram/tools.lua
+++ b/lua/telegram/tools.lua
@@ -196,7 +196,9 @@ M.register("members", {
 
 M.register("invitelinks", {
 	description = "Manage invite links",
-	condition = is_group,
+	condition = function()
+		return is_group() and (ui.state.permissions.can_invite_users == true)
+	end,
 	callback = function()
 		if not ui.state.chat_id then
 			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })

--- a/lua/telegram/tools.lua
+++ b/lua/telegram/tools.lua
@@ -134,6 +134,14 @@ M.register("search", {
 	end,
 })
 
+local function is_service()
+	local t = ui.curr_msg()
+	if not t or not t.type then return false end
+	return t.type:find("Chat") or t.type:find("Group") or t.type:find("Service")
+		or t.type:find("Forum") or t.type:find("^messagePin")
+		or t.type == "messageScreenshotTaken" or t.type == "messageCustomServiceAction"
+end
+
 local function open_target(target)
 	vim.fn.jobstart({
 		"sh", "-c",
@@ -144,6 +152,7 @@ end
 M.register("openlink", {
 	description = "Open URL or media file under cursor",
 	condition = function()
+		if is_service() then return false end
 		local cursor = vim.api.nvim_win_get_cursor(ui.state.win)
 		local text = vim.api.nvim_buf_get_lines(ui.state.buf, cursor[1] - 1, cursor[1], false)[1]
 		if not text then return false end
@@ -223,6 +232,7 @@ M.register("groupsettings", {
 M.register("refreshmedia", {
 	description = "Download and update image for message under cursor",
 	condition = function()
+		if is_service() then return false end
 		local t = ui.curr_msg()
 		return t and t.type and t.type ~= "messageText" and t.type:find("^message")
 	end,

--- a/lua/telegram/tools.lua
+++ b/lua/telegram/tools.lua
@@ -78,7 +78,9 @@ M.register("refresh", {
 
 M.register("send", {
 	description = "Send a message to current chat",
-	condition = function() return ui.state.chat_id ~= nil end,
+	condition = function()
+		return ui.state.chat_id ~= nil and ui.state.permissions.can_send_messages == true
+	end,
 	callback = function()
 		if not ui.state.chat_id then
 			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
@@ -105,30 +107,35 @@ M.register("search", {
 			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
 			return
 		end
+		local chat_id = ui.state.chat_id
 		vim.ui.input({ prompt = "Search: " }, function(query)
 			if not query or #query == 0 then
 				return
 			end
-			local data = server.search_messages(ui.state.chat_id, query)
-			if not data or not data.messages or #data.messages == 0 then
-				vim.notify('No results for "' .. query .. '"', vim.log.levels.INFO, { title = "tg" })
-				return
-			end
-			local items = {}
-			for _, m in ipairs(data.messages) do
-				local name = m.sender and m.sender.name or "?"
-				local preview = (m.text or ""):gsub("\n", " "):sub(1, 80)
-				table.insert(items, { id = m.id, label = name .. ": " .. preview })
-			end
-			vim.ui.select(items, {
-				prompt = "Search: " .. query,
-				format_item = function(item)
-					return item.label
-				end,
-			}, function(choice)
-				if choice then
-					ui.jump_to_message(choice.id)
+			vim.notify("Searching...", vim.log.levels.INFO, { title = "tg" })
+			server.search_messages_async(chat_id, query, function(data)
+				if not data or not data.messages or #data.messages == 0 then
+					vim.notify('No results for "' .. query .. '"', vim.log.levels.INFO, { title = "tg" })
+					return
 				end
+				local items = {}
+				for _, m in ipairs(data.messages) do
+					local name = m.sender and m.sender.name or "?"
+					local preview = (m.text or ""):gsub("\n", " "):sub(1, 80)
+					table.insert(items, { id = m.id, label = name .. ": " .. preview })
+				end
+				vim.ui.select(items, {
+					prompt = "Search: " .. query,
+					format_item = function(item)
+						return item.label
+					end,
+				}, function(choice)
+					if choice then
+						ui.jump_to_message(choice.id)
+					end
+				end)
+			end, function()
+				vim.notify("Search failed", vim.log.levels.ERROR, { title = "tg" })
 			end)
 		end)
 	end,
@@ -188,12 +195,24 @@ local function is_group()
 	local cid = ui.state.chat_id
 	if not cid then return false end
 	local g = ui.state.groups[cid]
-	return g and g.type ~= "private"
+	return g and g.type == "group"
+end
+
+local function is_channel()
+	local cid = ui.state.chat_id
+	if not cid then return false end
+	local g = ui.state.groups[cid]
+	return g and g.type == "channel"
 end
 
 M.register("members", {
 	description = "View and manage chat members",
-	condition = is_group,
+	condition = function()
+		if is_channel() then
+			return ui.state.permissions.can_manage_chat == true
+		end
+		return is_group()
+	end,
 	callback = function()
 		if not ui.state.chat_id then
 			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })
@@ -206,7 +225,7 @@ M.register("members", {
 M.register("invitelinks", {
 	description = "Manage invite links",
 	condition = function()
-		return is_group() and (ui.state.permissions.can_invite_users == true)
+		return is_group() and not is_channel() and (ui.state.permissions.can_invite_users == true)
 	end,
 	callback = function()
 		if not ui.state.chat_id then
@@ -218,8 +237,8 @@ M.register("invitelinks", {
 })
 
 M.register("groupsettings", {
-	description = "Group settings (title, description, permissions, etc.)",
-	condition = is_group,
+	description = "Group / channel settings (title, description, permissions, etc.)",
+	condition = function() return is_group() or is_channel() end,
 	callback = function()
 		if not ui.state.chat_id then
 			vim.notify("No chat open", vim.log.levels.WARN, { title = "tg" })

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -265,7 +265,9 @@ local function show_groups_picker(on_select)
 			prompt = "Select chat:",
 			format_item = function(item)
 				local label = item.title
-				if item.type == "private" then
+				if item.type == "channel" then
+					label = "# " .. label
+				elseif item.type == "private" then
 					label = "\xE2\x9C\x89 " .. label
 				end
 				if item.unread > 0 then
@@ -465,6 +467,10 @@ local function setup_chat_keymaps()
 
 	vim.keymap.set("n", "@", tools.pick, { buffer = buf, nowait = true })
 	vim.keymap.set("n", "i", function()
+		if state.permissions.can_send_messages ~= true then
+			vim.notify("No permission to send messages", vim.log.levels.WARN, { title = "tg" })
+			return
+		end
 		M.open_editor("Send", "", function(text)
 			if not text then
 				return
@@ -897,6 +903,7 @@ function M.open_chat(chat_id, chat_title)
 		state.messages = {}
 		state.exhausted = false
 		state.exhausted_forward = false
+		render()
 		local cid = state.chat_id
 		server.get_messages_around_async(state.chat_id, saved_id, 31, function(data)
 			if state.chat_id == cid then
@@ -919,6 +926,10 @@ function M.open_chat(chat_id, chat_title)
 			end
 		end)
 	else
+		state.messages = {}
+		state.exhausted = false
+		state.exhausted_forward = false
+		render()
 		M.refresh_messages(function()
 			M.jump_to_bottom()
 		end)
@@ -1314,20 +1325,30 @@ function M.show_invite_links(chat_id)
 	end)
 end
 
+local function is_channel()
+	local g = state.chat_id and state.groups[state.chat_id]
+	return g and g.type == "channel"
+end
+
 ---@param chat_id any
 function M.show_group_settings(chat_id)
+	local channel = is_channel()
 	local actions = {}
 	if can("can_change_info") then
 		table.insert(actions, "Change title")
 		table.insert(actions, "Change description")
 	end
-	if can("can_invite_users") then
+	if not channel and can("can_invite_users") then
 		table.insert(actions, "Add member")
 	end
-	if can("can_restrict_members") then
+	if not channel and can("can_restrict_members") then
 		table.insert(actions, "Set default permissions")
 	end
-	table.insert(actions, "Leave group")
+	if channel then
+		table.insert(actions, "Unsubscribe from channel")
+	else
+		table.insert(actions, "Leave group")
+	end
 	table.insert(actions, "Delete history")
 	table.insert(actions, "Cancel")
 	vim.ui.select(actions, {
@@ -1391,6 +1412,26 @@ function M.show_group_settings(chat_id)
 				if server.set_default_permissions(chat_id, restrict) then
 					state.default_restricted = restrict
 					vim.notify("Permissions " .. (restrict and "restricted" or "allowed"), vim.log.levels.INFO, { title = "tg" })
+				end
+			end)
+		elseif choice == "Unsubscribe from channel" then
+			vim.ui.select({ "Yes, unsubscribe", "Cancel" }, {
+				prompt = "Unsubscribe from this channel?",
+			}, function(confirm)
+				if confirm == "Yes, unsubscribe" then
+					if server.delete_chat_history(chat_id) then
+						state.groups[chat_id] = nil
+						for i, id in ipairs(state.group_ids) do
+							if id == chat_id then
+								table.remove(state.group_ids, i)
+								break
+							end
+						end
+						vim.notify("Unsubscribed from channel", vim.log.levels.INFO, { title = "tg" })
+						vim.schedule(function()
+							M.destroy_chat()
+						end)
+					end
 				end
 			end)
 		elseif choice == "Leave group" then

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -38,6 +38,8 @@ local state = {
 	_input_start = 0,
 
 	group_cursor = 1,
+	permissions = {},
+	description = "",
 }
 
 M.state = state
@@ -650,7 +652,6 @@ function M.show_help()
 		"-- Tools (@) --",
 		" chats      switch chat (Snacks picker)",
 		" members    view and manage members",
-		" admins     view administrators",
 		" invitelinks  manage invite links",
 		" groupsettings  group settings menu",
 		" refresh    reload messages",
@@ -878,7 +879,14 @@ function M.open_chat(chat_id, chat_title)
 	local chat_info = server.get_chat(state.chat_id)
 	if chat_info then
 		state.online_count = chat_info.onlineMemberCount or state.online_count
+		state.description = chat_info.description or ""
 		M.update_title()
+	end
+
+	state.permissions = {}
+	local perms = server.get_my_permissions(state.chat_id)
+	if perms then
+		state.permissions = perms
 	end
 
 	local saved_id = state.saved_cursors and state.saved_cursors[state.chat_id]
@@ -1166,8 +1174,24 @@ M.show_groups_picker = show_groups_picker
 
 -- ─── Group Management UI ────────────────────────────────────────────────
 
+local function can(perm)
+	return state.permissions and state.permissions[perm] == true
+end
+
 local function user_actions_menu(chat_id, user, on_done)
-	vim.ui.select({ "Ban", "Unban", "Promote to admin", "Demote", "Restrict", "Unrestrict", "Cancel" }, {
+	local actions = {}
+	if can("can_restrict_members") then
+		table.insert(actions, "Ban")
+		table.insert(actions, "Unban")
+		table.insert(actions, "Restrict")
+		table.insert(actions, "Unrestrict")
+	end
+	if can("can_promote_members") then
+		table.insert(actions, "Promote to admin")
+		table.insert(actions, "Demote")
+	end
+	table.insert(actions, "Cancel")
+	vim.ui.select(actions, {
 		prompt = user.name .. " (" .. user.status .. "):",
 	}, function(choice)
 		if not choice or choice == "Cancel" then
@@ -1220,26 +1244,15 @@ function M.show_member_list(chat_id)
 end
 
 ---@param chat_id any
-function M.show_admin_list(chat_id)
-	local data = server.get_admins(chat_id)
-	if not data or not data.members then
-		vim.notify("Failed to load admins", vim.log.levels.ERROR, { title = "tg" })
-		return
-	end
-	local items = {}
-	for _, m in ipairs(data.members) do
-		table.insert(items, m.name .. " (" .. m.status .. ")")
-	end
-	if #items == 0 then
-		vim.notify("No admins found", vim.log.levels.INFO, { title = "tg" })
-		return
-	end
-	vim.notify(table.concat(items, "\n"), vim.log.levels.INFO, { title = "Admins of " .. (state.chat_title or "") })
-end
-
----@param chat_id any
 function M.show_invite_links(chat_id)
-	vim.ui.select({ "Create new invite link", "View existing links", "Revoke a link", "Cancel" }, {
+	local actions = {}
+	if can("can_invite_users") then
+		table.insert(actions, "Create new invite link")
+		table.insert(actions, "Revoke a link")
+	end
+	table.insert(actions, "View existing links")
+	table.insert(actions, "Cancel")
+	vim.ui.select(actions, {
 		prompt = "Invite Links",
 	}, function(choice)
 		if not choice or choice == "Cancel" then return end
@@ -1292,22 +1305,40 @@ end
 
 ---@param chat_id any
 function M.show_group_settings(chat_id)
-	vim.ui.select({ "Change title", "Change description", "Add member", "Set default permissions", "Set slow mode", "Leave group", "Delete history", "Cancel" }, {
+	local actions = {}
+	if can("can_change_info") then
+		table.insert(actions, "Change title")
+		table.insert(actions, "Change description")
+	end
+	if can("can_invite_users") then
+		table.insert(actions, "Add member")
+	end
+	if can("can_restrict_members") then
+		table.insert(actions, "Set default permissions")
+		table.insert(actions, "Set slow mode")
+	end
+	table.insert(actions, "Leave group")
+	table.insert(actions, "Delete history")
+	table.insert(actions, "Cancel")
+	vim.ui.select(actions, {
 		prompt = "Group Settings",
 	}, function(choice)
 		if not choice or choice == "Cancel" then return end
 		if choice == "Change title" then
-			vim.ui.input({ prompt = "New title: " }, function(title)
+			vim.ui.input({ prompt = "New title: ", default = state.chat_title }, function(title)
 				if title and #title > 0 then
 					if server.set_chat_title(chat_id, title) then
 						state.chat_title = title
+						if state.groups[chat_id] then
+							state.groups[chat_id].title = title
+						end
 						M.update_title()
 						vim.notify("Title updated", vim.log.levels.INFO, { title = "tg" })
 					end
 				end
 			end)
 		elseif choice == "Change description" then
-			vim.ui.input({ prompt = "New description: " }, function(desc)
+			vim.ui.input({ prompt = "New description: ", default = state.description }, function(desc)
 				if desc then
 					if server.set_chat_description(chat_id, desc) then
 						vim.notify("Description updated", vim.log.levels.INFO, { title = "tg" })
@@ -1384,6 +1415,10 @@ function M.show_user_actions(chat_id, user_id, user_name)
 end
 
 function M.ban_sender()
+	if not can("can_restrict_members") then
+		vim.notify("No permission to restrict members", vim.log.levels.WARN, { title = "tg" })
+		return
+	end
 	local target = M.curr_msg()
 	if not target or not target.sender or not target.sender.id then
 		vim.notify("No message at cursor", vim.log.levels.WARN, { title = "tg" })

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -40,6 +40,7 @@ local state = {
 	group_cursor = 1,
 	permissions = {},
 	my_user_id = nil,
+	default_restricted = false,
 }
 
 M.state = state
@@ -880,6 +881,7 @@ function M.open_chat(chat_id, chat_title)
 	if chat_info then
 		state.online_count = chat_info.onlineMemberCount or state.online_count
 		state.description = chat_info.description or ""
+		state.default_restricted = chat_info.defaultRestricted or false
 		M.update_title()
 	end
 
@@ -1324,7 +1326,6 @@ function M.show_group_settings(chat_id)
 	end
 	if can("can_restrict_members") then
 		table.insert(actions, "Set default permissions")
-		table.insert(actions, "Set slow mode")
 	end
 	table.insert(actions, "Leave group")
 	table.insert(actions, "Delete history")
@@ -1371,22 +1372,21 @@ function M.show_group_settings(chat_id)
 				end
 			end)
 		elseif choice == "Set default permissions" then
-			vim.ui.select({ "Allow all (default)", "Restrict all", "Cancel" }, {
+			local restrict_options = { "Normal (send)", "Restrict all (read only)" }
+			for i, v in ipairs(restrict_options) do
+				local is_restrict = v:find("^Restrict") ~= nil
+				local on = is_restrict == state.default_restricted
+				restrict_options[i] = on and v .. " (current)" or v
+			end
+			table.insert(restrict_options, "Cancel")
+			vim.ui.select(restrict_options, {
 				prompt = "Default permissions for new members",
 			}, function(perm_choice)
 				if not perm_choice or perm_choice == "Cancel" then return end
-				local restrict = perm_choice == "Restrict all"
+				local restrict = perm_choice:find("^Restrict") ~= nil
 				if server.set_default_permissions(chat_id, restrict) then
-					vim.notify("Permissions updated", vim.log.levels.INFO, { title = "tg" })
-				end
-			end)
-		elseif choice == "Set slow mode" then
-			vim.ui.input({ prompt = "Slow mode delay in seconds (0 = off): " }, function(delay)
-				local d = delay and tonumber(delay)
-				if d ~= nil then
-					if server.set_slow_mode(chat_id, d) then
-						vim.notify("Slow mode set to " .. d .. "s", vim.log.levels.INFO, { title = "tg" })
-					end
+					state.default_restricted = restrict
+					vim.notify("Permissions " .. (restrict and "restricted" or "allowed"), vim.log.levels.INFO, { title = "tg" })
 				end
 			end)
 		elseif choice == "Leave group" then

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -881,24 +881,38 @@ function M.open_chat(chat_id, chat_title)
 
 	server.open_chat(state.chat_id)
 
-	local cached = state.groups[state.chat_id]
+	local cid = state.chat_id
+	local cached = state.groups[cid]
 	state.online_count = (cached and cached.online_count) or 0
-	local chat_info = server.get_chat(state.chat_id)
-	if chat_info then
-		state.online_count = chat_info.onlineMemberCount or state.online_count
-		state.description = chat_info.description or ""
-		state.default_restricted = chat_info.defaultRestricted or false
-		M.update_title()
-	end
-
 	state.permissions = {}
-	local perms = server.get_my_permissions(state.chat_id)
-	if perms then
-		state.permissions = perms
-		state.my_user_id = perms.my_user_id
-	end
+	state.description = ""
 
-	local saved_id = state.saved_cursors and state.saved_cursors[state.chat_id]
+	local pending = 2
+	local function check_done()
+		pending = pending - 1
+		if pending == 0 then
+			M.update_title()
+		end
+	end
+	server.get_chat_async(cid, function(chat_info)
+		if state.chat_id ~= cid then return end
+		if chat_info then
+			state.online_count = chat_info.onlineMemberCount or state.online_count
+			state.description = chat_info.description or ""
+			state.default_restricted = chat_info.defaultRestricted or false
+		end
+		check_done()
+	end)
+	server.get_my_permissions_async(cid, function(perms)
+		if state.chat_id ~= cid then return end
+		if perms then
+			state.permissions = perms
+			state.my_user_id = perms.my_user_id
+		end
+		check_done()
+	end)
+
+	local saved_id = state.saved_cursors and state.saved_cursors[cid]
 	if saved_id then
 		state.messages = {}
 		state.exhausted = false
@@ -1240,28 +1254,30 @@ end
 
 ---@param chat_id any
 function M.show_member_list(chat_id)
-	local data = server.get_members(chat_id)
-	if not data or not data.members then
-		vim.notify("Failed to load members", vim.log.levels.ERROR, { title = "tg" })
-		return
-	end
-	local items = {}
-	for _, m in ipairs(data.members) do
-		if m.user_id ~= state.my_user_id then
-			table.insert(items, { user_id = m.user_id, name = m.name, status = m.status, label = status_icon(m.status) .. " " .. m.name .. " (" .. m.status .. ")" })
+	vim.notify("Loading members...", vim.log.levels.INFO, { title = "tg" })
+	server.get_members_async(chat_id, function(data)
+		if not data or not data.members then
+			vim.notify("Failed to load members", vim.log.levels.ERROR, { title = "tg" })
+			return
 		end
-	end
-	if #items == 0 then
-		vim.notify("No members found", vim.log.levels.INFO, { title = "tg" })
-		return
-	end
-	vim.ui.select(items, {
-		prompt = "Members (" .. #items .. ")",
-		format_item = function(item) return item.label end,
-	}, function(choice)
-		if choice then
-			user_actions_menu(chat_id, choice)
+		local items = {}
+		for _, m in ipairs(data.members) do
+			if m.user_id ~= state.my_user_id then
+				table.insert(items, { user_id = m.user_id, name = m.name, status = m.status, label = status_icon(m.status) .. " " .. m.name .. " (" .. m.status .. ")" })
+			end
 		end
+		if #items == 0 then
+			vim.notify("No members found", vim.log.levels.INFO, { title = "tg" })
+			return
+		end
+		vim.ui.select(items, {
+			prompt = "Members (" .. #items .. ")",
+			format_item = function(item) return item.label end,
+		}, function(choice)
+			if choice then
+				user_actions_menu(chat_id, choice)
+			end
+		end)
 	end)
 end
 
@@ -1287,39 +1303,43 @@ function M.show_invite_links(chat_id)
 				end
 			end)
 		elseif choice == "View existing links" then
-			local data = server.get_invite_links(chat_id)
-			if not data or not data.invite_links or #data.invite_links == 0 then
-				vim.notify("No invite links", vim.log.levels.INFO, { title = "tg" })
-				return
-			end
-			local lines = {}
-			for _, link in ipairs(data.invite_links) do
-				local info = link.invite_link
-				if link.member_limit and link.member_limit > 0 then
-					info = info .. " (limit: " .. link.member_limit .. ")"
+			vim.notify("Loading invite links...", vim.log.levels.INFO, { title = "tg" })
+			server.get_invite_links_async(chat_id, function(data)
+				if not data or not data.invite_links or #data.invite_links == 0 then
+					vim.notify("No invite links", vim.log.levels.INFO, { title = "tg" })
+					return
 				end
-				table.insert(lines, info)
-			end
-			vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO, { title = "Invite Links" })
-		elseif choice == "Revoke a link" then
-			local data = server.get_invite_links(chat_id)
-			if not data or not data.invite_links or #data.invite_links == 0 then
-				vim.notify("No invite links to revoke", vim.log.levels.INFO, { title = "tg" })
-				return
-			end
-			local items = {}
-			for _, link in ipairs(data.invite_links) do
-				table.insert(items, { link = link.invite_link, label = link.invite_link })
-			end
-			vim.ui.select(items, {
-				prompt = "Select link to revoke",
-				format_item = function(item) return item.label end,
-			}, function(choice)
-				if choice then
-					if server.revoke_invite_link(chat_id, choice.link) then
-						vim.notify("Link revoked", vim.log.levels.INFO, { title = "tg" })
+				local lines = {}
+				for _, link in ipairs(data.invite_links) do
+					local info = link.invite_link
+					if link.member_limit and link.member_limit > 0 then
+						info = info .. " (limit: " .. link.member_limit .. ")"
 					end
+					table.insert(lines, info)
 				end
+				vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO, { title = "Invite Links" })
+			end)
+		elseif choice == "Revoke a link" then
+			vim.notify("Loading invite links...", vim.log.levels.INFO, { title = "tg" })
+			server.get_invite_links_async(chat_id, function(data)
+				if not data or not data.invite_links or #data.invite_links == 0 then
+					vim.notify("No invite links to revoke", vim.log.levels.INFO, { title = "tg" })
+					return
+				end
+				local items = {}
+				for _, link in ipairs(data.invite_links) do
+					table.insert(items, { link = link.invite_link, label = link.invite_link })
+				end
+				vim.ui.select(items, {
+					prompt = "Select link to revoke",
+					format_item = function(item) return item.label end,
+				}, function(choice)
+					if choice then
+						if server.revoke_invite_link(chat_id, choice.link) then
+							vim.notify("Link revoked", vim.log.levels.INFO, { title = "tg" })
+						end
+					end
+				end)
 			end)
 		end
 	end)
@@ -1393,10 +1413,11 @@ function M.show_group_settings(chat_id)
 				end
 			end)
 		elseif choice == "Set default permissions" then
-			local chat_info = server.get_chat(chat_id)
-			if chat_info then
-				state.default_restricted = chat_info.defaultRestricted or false
-			end
+			server.get_chat_async(chat_id, function(chat_info)
+				if chat_info then
+					state.default_restricted = chat_info.defaultRestricted or false
+				end
+			end)
 			local restrict_options = { "Normal (send)", "Restrict all (read only)" }
 			for i, v in ipairs(restrict_options) do
 				local is_restrict = v:find("^Restrict") ~= nil

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -1372,6 +1372,10 @@ function M.show_group_settings(chat_id)
 				end
 			end)
 		elseif choice == "Set default permissions" then
+			local chat_info = server.get_chat(chat_id)
+			if chat_info then
+				state.default_restricted = chat_info.defaultRestricted or false
+			end
 			local restrict_options = { "Normal (send)", "Restrict all (read only)" }
 			for i, v in ipairs(restrict_options) do
 				local is_restrict = v:find("^Restrict") ~= nil

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -39,7 +39,7 @@ local state = {
 
 	group_cursor = 1,
 	permissions = {},
-	description = "",
+	my_user_id = nil,
 }
 
 M.state = state
@@ -887,6 +887,7 @@ function M.open_chat(chat_id, chat_title)
 	local perms = server.get_my_permissions(state.chat_id)
 	if perms then
 		state.permissions = perms
+		state.my_user_id = perms.my_user_id
 	end
 
 	local saved_id = state.saved_cursors and state.saved_cursors[state.chat_id]
@@ -1179,7 +1180,7 @@ local function can(perm)
 end
 
 local function user_actions_menu(chat_id, user, on_done)
-	local actions = {}
+	local actions = { "Open DM" }
 	if can("can_restrict_members") then
 		table.insert(actions, "Ban")
 		table.insert(actions, "Unban")
@@ -1199,7 +1200,13 @@ local function user_actions_menu(chat_id, user, on_done)
 			return
 		end
 		local ok = false
-		if choice == "Ban" then ok = server.ban_member(chat_id, user.user_id)
+		if choice == "Open DM" then
+			local chat = server.open_private_chat(user.user_id)
+			if chat then
+				M.open_chat(chat.id, chat.title)
+			end
+			ok = true
+		elseif choice == "Ban" then ok = server.ban_member(chat_id, user.user_id)
 		elseif choice == "Unban" then ok = server.unban_member(chat_id, user.user_id)
 		elseif choice == "Promote to admin" then ok = server.promote_member(chat_id, user.user_id)
 		elseif choice == "Demote" then ok = server.demote_member(chat_id, user.user_id)
@@ -1227,7 +1234,9 @@ function M.show_member_list(chat_id)
 	end
 	local items = {}
 	for _, m in ipairs(data.members) do
-		table.insert(items, { user_id = m.user_id, name = m.name, status = m.status, label = status_icon(m.status) .. " " .. m.name .. " (" .. m.status .. ")" })
+		if m.user_id ~= state.my_user_id then
+			table.insert(items, { user_id = m.user_id, name = m.name, status = m.status, label = status_icon(m.status) .. " " .. m.name .. " (" .. m.status .. ")" })
+		end
 	end
 	if #items == 0 then
 		vim.notify("No members found", vim.log.levels.INFO, { title = "tg" })

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -578,6 +578,9 @@ local function setup_chat_keymaps()
 			M.jump_to_bottom()
 		end)
 	end, { buffer = buf, nowait = true })
+	vim.keymap.set("n", "B", function()
+		M.ban_sender()
+	end, { buffer = buf, nowait = true })
 	vim.keymap.set("n", "c", function()
 		local target = M.curr_msg()
 		if not target or not target.sender or not target.sender.id then
@@ -641,10 +644,15 @@ function M.show_help()
 		" d          delete / revoke",
 		" f          forward message",
 		" G          refresh + jump to bottom",
+		" B          ban message sender",
 		" c          open DM with message sender",
 		"",
 		"-- Tools (@) --",
 		" chats      switch chat (Snacks picker)",
+		" members    view and manage members",
+		" admins     view administrators",
+		" invitelinks  manage invite links",
+		" groupsettings  group settings menu",
 		" refresh    reload messages",
 		" send       send a message",
 		" search     search history",
@@ -1155,5 +1163,250 @@ function M.refresh_messages(on_complete)
 end
 
 M.show_groups_picker = show_groups_picker
+
+-- ─── Group Management UI ────────────────────────────────────────────────
+
+local function user_actions_menu(chat_id, user, on_done)
+	vim.ui.select({ "Ban", "Unban", "Promote to admin", "Demote", "Restrict", "Unrestrict", "Cancel" }, {
+		prompt = user.name .. " (" .. user.status .. "):",
+	}, function(choice)
+		if not choice or choice == "Cancel" then
+			if on_done then on_done() end
+			return
+		end
+		local ok = false
+		if choice == "Ban" then ok = server.ban_member(chat_id, user.user_id)
+		elseif choice == "Unban" then ok = server.unban_member(chat_id, user.user_id)
+		elseif choice == "Promote to admin" then ok = server.promote_member(chat_id, user.user_id)
+		elseif choice == "Demote" then ok = server.demote_member(chat_id, user.user_id)
+		elseif choice == "Restrict" then ok = server.restrict_member(chat_id, user.user_id)
+		elseif choice == "Unrestrict" then ok = server.unrestrict_member(chat_id, user.user_id)
+		end
+		if ok then
+			vim.notify(choice .. ": " .. user.name, vim.log.levels.INFO, { title = "tg" })
+		end
+		if on_done then on_done() end
+	end)
+end
+
+local function status_icon(status)
+	local icons = { creator = "\xE2\xAD\x90", administrator = "\xE2\x9C\xA8", member = "\xF0\x9F\x91\xA4", restricted = "\xE2\x9B\x94", banned = "\xE2\x9D\x8C", left = "\xE2\x9C\x8C" }
+	return icons[status] or ""
+end
+
+---@param chat_id any
+function M.show_member_list(chat_id)
+	local data = server.get_members(chat_id)
+	if not data or not data.members then
+		vim.notify("Failed to load members", vim.log.levels.ERROR, { title = "tg" })
+		return
+	end
+	local items = {}
+	for _, m in ipairs(data.members) do
+		table.insert(items, { user_id = m.user_id, name = m.name, status = m.status, label = status_icon(m.status) .. " " .. m.name .. " (" .. m.status .. ")" })
+	end
+	if #items == 0 then
+		vim.notify("No members found", vim.log.levels.INFO, { title = "tg" })
+		return
+	end
+	vim.ui.select(items, {
+		prompt = "Members (" .. #items .. ")",
+		format_item = function(item) return item.label end,
+	}, function(choice)
+		if choice then
+			user_actions_menu(chat_id, choice)
+		end
+	end)
+end
+
+---@param chat_id any
+function M.show_admin_list(chat_id)
+	local data = server.get_admins(chat_id)
+	if not data or not data.members then
+		vim.notify("Failed to load admins", vim.log.levels.ERROR, { title = "tg" })
+		return
+	end
+	local items = {}
+	for _, m in ipairs(data.members) do
+		table.insert(items, m.name .. " (" .. m.status .. ")")
+	end
+	if #items == 0 then
+		vim.notify("No admins found", vim.log.levels.INFO, { title = "tg" })
+		return
+	end
+	vim.notify(table.concat(items, "\n"), vim.log.levels.INFO, { title = "Admins of " .. (state.chat_title or "") })
+end
+
+---@param chat_id any
+function M.show_invite_links(chat_id)
+	vim.ui.select({ "Create new invite link", "View existing links", "Revoke a link", "Cancel" }, {
+		prompt = "Invite Links",
+	}, function(choice)
+		if not choice or choice == "Cancel" then return end
+		if choice == "Create new invite link" then
+			vim.ui.input({ prompt = "Member limit (0 = unlimited): " }, function(limit)
+				local member_limit = limit and tonumber(limit) or nil
+				if member_limit and member_limit <= 0 then member_limit = nil end
+				if server.create_invite_link(chat_id, nil, member_limit) then
+					vim.notify("Invite link created!", vim.log.levels.INFO, { title = "tg" })
+				end
+			end)
+		elseif choice == "View existing links" then
+			local data = server.get_invite_links(chat_id)
+			if not data or not data.invite_links or #data.invite_links == 0 then
+				vim.notify("No invite links", vim.log.levels.INFO, { title = "tg" })
+				return
+			end
+			local lines = {}
+			for _, link in ipairs(data.invite_links) do
+				local info = link.invite_link
+				if link.member_limit and link.member_limit > 0 then
+					info = info .. " (limit: " .. link.member_limit .. ")"
+				end
+				table.insert(lines, info)
+			end
+			vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO, { title = "Invite Links" })
+		elseif choice == "Revoke a link" then
+			local data = server.get_invite_links(chat_id)
+			if not data or not data.invite_links or #data.invite_links == 0 then
+				vim.notify("No invite links to revoke", vim.log.levels.INFO, { title = "tg" })
+				return
+			end
+			local items = {}
+			for _, link in ipairs(data.invite_links) do
+				table.insert(items, { link = link.invite_link, label = link.invite_link })
+			end
+			vim.ui.select(items, {
+				prompt = "Select link to revoke",
+				format_item = function(item) return item.label end,
+			}, function(choice)
+				if choice then
+					if server.revoke_invite_link(chat_id, choice.link) then
+						vim.notify("Link revoked", vim.log.levels.INFO, { title = "tg" })
+					end
+				end
+			end)
+		end
+	end)
+end
+
+---@param chat_id any
+function M.show_group_settings(chat_id)
+	vim.ui.select({ "Change title", "Change description", "Add member", "Set default permissions", "Set slow mode", "Leave group", "Delete history", "Cancel" }, {
+		prompt = "Group Settings",
+	}, function(choice)
+		if not choice or choice == "Cancel" then return end
+		if choice == "Change title" then
+			vim.ui.input({ prompt = "New title: " }, function(title)
+				if title and #title > 0 then
+					if server.set_chat_title(chat_id, title) then
+						state.chat_title = title
+						M.update_title()
+						vim.notify("Title updated", vim.log.levels.INFO, { title = "tg" })
+					end
+				end
+			end)
+		elseif choice == "Change description" then
+			vim.ui.input({ prompt = "New description: " }, function(desc)
+				if desc then
+					if server.set_chat_description(chat_id, desc) then
+						vim.notify("Description updated", vim.log.levels.INFO, { title = "tg" })
+					end
+				end
+			end)
+		elseif choice == "Add member" then
+			vim.ui.input({ prompt = "User ID to add: " }, function(user_id)
+				if user_id and #user_id > 0 then
+					local id = tonumber(user_id)
+					if not id then
+						vim.notify("Invalid user ID", vim.log.levels.ERROR, { title = "tg" })
+						return
+					end
+					local ok, err = server.add_member(chat_id, id)
+					if ok then
+						vim.notify("Member added", vim.log.levels.INFO, { title = "tg" })
+					else
+						vim.notify(err or "Failed to add member", vim.log.levels.ERROR, { title = "tg" })
+					end
+				end
+			end)
+		elseif choice == "Set default permissions" then
+			vim.ui.select({ "Allow all (default)", "Restrict all", "Cancel" }, {
+				prompt = "Default permissions for new members",
+			}, function(perm_choice)
+				if not perm_choice or perm_choice == "Cancel" then return end
+				local restrict = perm_choice == "Restrict all"
+				if server.set_default_permissions(chat_id, restrict) then
+					vim.notify("Permissions updated", vim.log.levels.INFO, { title = "tg" })
+				end
+			end)
+		elseif choice == "Set slow mode" then
+			vim.ui.input({ prompt = "Slow mode delay in seconds (0 = off): " }, function(delay)
+				local d = delay and tonumber(delay)
+				if d ~= nil then
+					if server.set_slow_mode(chat_id, d) then
+						vim.notify("Slow mode set to " .. d .. "s", vim.log.levels.INFO, { title = "tg" })
+					end
+				end
+			end)
+		elseif choice == "Leave group" then
+			vim.ui.select({ "Yes, leave", "Cancel" }, {
+				prompt = "Are you sure you want to leave this group?",
+			}, function(confirm)
+				if confirm == "Yes, leave" then
+					if server.leave_chat(chat_id) then
+						vim.notify("Left group", vim.log.levels.INFO, { title = "tg" })
+						vim.schedule(function()
+							M.destroy_chat()
+						end)
+					end
+				end
+			end)
+		elseif choice == "Delete history" then
+			vim.ui.select({ "Yes, delete history", "Cancel" }, {
+				prompt = "Delete chat history permanently?",
+			}, function(confirm)
+				if confirm == "Yes, delete history" then
+					if server.delete_chat_history(chat_id) then
+						vim.notify("History deleted", vim.log.levels.INFO, { title = "tg" })
+					end
+				end
+			end)
+		end
+	end)
+end
+
+---@param chat_id any
+---@param user_id any
+---@param user_name string
+function M.show_user_actions(chat_id, user_id, user_name)
+	user_actions_menu(chat_id, { user_id = user_id, name = user_name, status = "member" })
+end
+
+function M.ban_sender()
+	local target = M.curr_msg()
+	if not target or not target.sender or not target.sender.id then
+		vim.notify("No message at cursor", vim.log.levels.WARN, { title = "tg" })
+		return
+	end
+	if target.own then
+		vim.notify("Cannot ban yourself", vim.log.levels.WARN, { title = "tg" })
+		return
+	end
+	local user_id = tonumber(target.sender.id)
+	if not user_id then
+		vim.notify("Cannot identify sender", vim.log.levels.WARN, { title = "tg" })
+		return
+	end
+	vim.ui.select({ "Ban " .. target.sender.name, "Cancel" }, {
+		prompt = "Ban user?",
+	}, function(choice)
+		if choice and choice ~= "Cancel" then
+			if server.ban_member(state.chat_id, user_id) then
+				vim.notify("Banned " .. target.sender.name, vim.log.levels.INFO, { title = "tg" })
+			end
+		end
+	end)
+end
 
 return M

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -1399,6 +1399,13 @@ function M.show_group_settings(chat_id)
 			}, function(confirm)
 				if confirm == "Yes, leave" then
 					if server.leave_chat(chat_id) then
+						state.groups[chat_id] = nil
+						for i, id in ipairs(state.group_ids) do
+							if id == chat_id then
+								table.remove(state.group_ids, i)
+								break
+							end
+						end
 						vim.notify("Left group", vim.log.levels.INFO, { title = "tg" })
 						vim.schedule(function()
 							M.destroy_chat()

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -1248,9 +1248,9 @@ function M.show_invite_links(chat_id)
 	local actions = {}
 	if can("can_invite_users") then
 		table.insert(actions, "Create new invite link")
+		table.insert(actions, "View existing links")
 		table.insert(actions, "Revoke a link")
 	end
-	table.insert(actions, "View existing links")
 	table.insert(actions, "Cancel")
 	vim.ui.select(actions, {
 		prompt = "Invite Links",

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -1190,8 +1190,8 @@ function M.refresh_messages(on_complete)
 		if on_complete then
 			on_complete()
 		end
-	end, function()
-		vim.notify("Failed to load messages", vim.log.levels.ERROR, { title = "tg" })
+	end, function(err)
+		vim.notify("Failed to load messages: " .. tostring(err), vim.log.levels.ERROR, { title = "tg" })
 		if on_complete then
 			on_complete()
 		end

--- a/src/client.ts
+++ b/src/client.ts
@@ -235,9 +235,16 @@ export class TelegramLSPClient {
     const chats = await this.getChats(true);
     const results = chats.map(async (chat) => {
       const t = chat.type._;
-      if (t === 'chatTypeBasicGroup' || (t === 'chatTypeSupergroup' && !chat.type.is_channel)) {
+      if (t === 'chatTypeBasicGroup') {
         const g = await this._enrichGroup(chat);
         return g ? { ...g, type: 'group' as const } : null;
+      }
+      if (t === 'chatTypeSupergroup') {
+        const g = await this._enrichGroup(chat);
+        if (!g) return null;
+        return chat.type.is_channel
+          ? { ...g, type: 'channel' as const }
+          : { ...g, type: 'group' as const };
       }
       if (t === 'chatTypePrivate' || t === 'chatTypeSecret') {
         return this._enrichPrivate(chat);
@@ -769,6 +776,7 @@ export class TelegramLSPClient {
         my_user_id: me.id,
         is_owner: false,
         is_admin: false,
+        can_send_messages: false,
         can_restrict_members: false,
         can_promote_members: false,
         can_change_info: false,
@@ -781,9 +789,11 @@ export class TelegramLSPClient {
       if (chat.type._ === 'chatTypeSupergroup') {
         const sg: any = await this.client.invoke({ _: 'getSupergroup', supergroup_id: chat.type.supergroup_id });
         const s = sg.status;
+        const isChannel = !!chat.type.is_channel;
         if (s._ === 'chatMemberStatusCreator') {
           perms.is_owner = true;
           perms.is_admin = true;
+          perms.can_send_messages = true;
           perms.can_restrict_members = true;
           perms.can_promote_members = true;
           perms.can_change_info = true;
@@ -793,6 +803,7 @@ export class TelegramLSPClient {
           perms.can_manage_chat = true;
         } else if (s._ === 'chatMemberStatusAdministrator') {
           perms.is_admin = true;
+          perms.can_send_messages = isChannel ? !!s.can_post_messages : true;
           perms.can_restrict_members = !!s.can_restrict_members;
           perms.can_promote_members = !!s.can_promote_members;
           perms.can_change_info = !!s.can_change_info;
@@ -801,12 +812,16 @@ export class TelegramLSPClient {
           perms.can_delete_messages = !!s.can_delete_messages;
           perms.can_manage_chat = !!s.can_manage_chat;
         }
+        if (isChannel && s._ === 'chatMemberStatusMember') {
+          perms.can_send_messages = false;
+        }
       } else if (chat.type._ === 'chatTypeBasicGroup') {
         const bg: any = await this.client.invoke({ _: 'getBasicGroup', basic_group_id: chat.type.basic_group_id });
         const s = bg.status;
         if (s._ === 'chatMemberStatusCreator') {
           perms.is_owner = true;
           perms.is_admin = true;
+          perms.can_send_messages = true;
           perms.can_restrict_members = true;
           perms.can_promote_members = true;
           perms.can_change_info = true;
@@ -816,6 +831,7 @@ export class TelegramLSPClient {
           perms.can_manage_chat = true;
         } else if (s._ === 'chatMemberStatusAdministrator') {
           perms.is_admin = true;
+          perms.can_send_messages = true;
           perms.can_restrict_members = true;
           perms.can_promote_members = true;
           perms.can_change_info = true;

--- a/src/client.ts
+++ b/src/client.ts
@@ -490,6 +490,274 @@ export class TelegramLSPClient {
     return { chat: { id: chatId, title: chat ? chat.title : 'Unknown group' }, messages: msgs };
   }
 
+  // ─── Member Management ───────────────────────────────────────────────
+
+  async banChatMember(chatId: number, userId: number): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'setChatMemberStatus',
+      chat_id: chatId,
+      member_id: { _: 'messageSenderUser', user_id: userId },
+      status: { _: 'chatMemberStatusBanned' },
+    });
+    return { ok: true };
+  }
+
+  async unbanChatMember(chatId: number, userId: number): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'setChatMemberStatus',
+      chat_id: chatId,
+      member_id: { _: 'messageSenderUser', user_id: userId },
+      status: { _: 'chatMemberStatusMember' },
+    });
+    return { ok: true };
+  }
+
+  async promoteChatMember(chatId: number, userId: number): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'setChatMemberStatus',
+      chat_id: chatId,
+      member_id: { _: 'messageSenderUser', user_id: userId },
+      status: {
+        _: 'chatMemberStatusAdministrator',
+        custom_title: '',
+        is_anonymous: false,
+        can_manage_chat: true,
+        can_change_info: true,
+        can_post_messages: true,
+        can_edit_messages: true,
+        can_delete_messages: true,
+        can_invite_users: true,
+        can_restrict_members: true,
+        can_pin_messages: true,
+        can_manage_topics: true,
+        can_promote_members: true,
+        can_manage_video_chats: true,
+        can_post_stories: true,
+        can_edit_stories: true,
+        can_delete_stories: true,
+      },
+    });
+    return { ok: true };
+  }
+
+  async demoteChatMember(chatId: number, userId: number): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'setChatMemberStatus',
+      chat_id: chatId,
+      member_id: { _: 'messageSenderUser', user_id: userId },
+      status: { _: 'chatMemberStatusMember' },
+    });
+    return { ok: true };
+  }
+
+  async restrictChatMember(chatId: number, userId: number, untilDate = 0): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'setChatMemberStatus',
+      chat_id: chatId,
+      member_id: { _: 'messageSenderUser', user_id: userId },
+      status: {
+        _: 'chatMemberStatusRestricted',
+        is_member: true,
+        permissions: {
+          _: 'chatPermissions',
+          can_send_messages: false,
+          can_send_audios: false,
+          can_send_documents: false,
+          can_send_photos: false,
+          can_send_videos: false,
+          can_send_video_notes: false,
+          can_send_voice_notes: false,
+          can_send_polls: false,
+          can_send_other_messages: false,
+          can_add_web_page_previews: false,
+          can_change_info: false,
+          can_invite_users: false,
+          can_pin_messages: false,
+          can_manage_topics: false,
+        },
+        until_date: untilDate,
+      },
+    });
+    return { ok: true };
+  }
+
+  async unrestrictChatMember(chatId: number, userId: number): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'setChatMemberStatus',
+      chat_id: chatId,
+      member_id: { _: 'messageSenderUser', user_id: userId },
+      status: {
+        _: 'chatMemberStatusRestricted',
+        is_member: true,
+        permissions: {
+          _: 'chatPermissions',
+          can_send_messages: true,
+          can_send_audios: true,
+          can_send_documents: true,
+          can_send_photos: true,
+          can_send_videos: true,
+          can_send_video_notes: true,
+          can_send_voice_notes: true,
+          can_send_polls: true,
+          can_send_other_messages: true,
+          can_add_web_page_previews: true,
+          can_change_info: true,
+          can_invite_users: true,
+          can_pin_messages: true,
+          can_manage_topics: true,
+        },
+        until_date: 0,
+      },
+    });
+    return { ok: true };
+  }
+
+  async addChatMember(chatId: number, userId: number): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    const chat = await this.getRawChat(chatId);
+    if (chat.type._ === 'chatTypeBasicGroup') {
+      await this.client.invoke({ _: 'addChatMember', chat_id: chatId, user_id: userId });
+    } else {
+      // For supergroups, share an invite link instead
+      const link = await this.createChatInviteLink(chatId);
+      throw new Error(`Cannot add member directly to a supergroup. Share this invite link: ${link.invite_link || 'failed to generate'}`);
+    }
+    return { ok: true };
+  }
+
+  async searchChatMembers(chatId: number, query = '', limit = 200): Promise<any[]> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    const result = await this.client.invoke({
+      _: 'searchChatMembers',
+      chat_id: chatId,
+      query,
+      limit,
+      filter: { _: 'chatMembersFilterMembers' },
+    }) as { members?: any[] };
+    return this._resolveChatMembers(result.members || []);
+  }
+
+  async getChatAdministrators(chatId: number): Promise<any[]> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    const result = await this.client.invoke({
+      _: 'getChatAdministrators',
+      chat_id: chatId,
+    }) as any[];
+    return this._resolveChatMembers(result || []);
+  }
+
+  async setChatDefaultPermissions(chatId: number, permissions: Record<string, boolean>): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'setChatPermissions',
+      chat_id: chatId,
+      permissions: { _: 'chatPermissions', ...permissions },
+    });
+    return { ok: true };
+  }
+
+  async setChatSlowModeDelay(chatId: number, delaySeconds: number): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'setChatSlowModeDelay',
+      chat_id: chatId,
+      slow_mode_delay: delaySeconds,
+    });
+    return { ok: true };
+  }
+
+  // ─── Group Settings ─────────────────────────────────────────────────
+
+  async setChatTitle(chatId: number, title: string): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({ _: 'setChatTitle', chat_id: chatId, title });
+    return { ok: true };
+  }
+
+  async setChatDescription(chatId: number, description: string): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({ _: 'setChatDescription', chat_id: chatId, description });
+    return { ok: true };
+  }
+
+  async leaveChat(chatId: number): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({ _: 'leaveChat', chat_id: chatId });
+    return { ok: true };
+  }
+
+  async deleteChatHistory(chatId: number, removeFromChatList = true): Promise<{ ok: boolean }> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    await this.client.invoke({
+      _: 'deleteChatHistory',
+      chat_id: chatId,
+      remove_from_chat_list: removeFromChatList,
+      revoke: false,
+    });
+    return { ok: true };
+  }
+
+  // ─── Invite Links ───────────────────────────────────────────────────
+
+  async createChatInviteLink(chatId: number, expireDate?: number, memberLimit?: number): Promise<any> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    const params: Record<string, unknown> = { _: 'createChatInviteLink', chat_id: chatId };
+    if (expireDate !== undefined) params.expire_date = expireDate;
+    if (memberLimit !== undefined) params.member_limit = memberLimit;
+    return await this.client.invoke(params);
+  }
+
+  async getChatInviteLinks(chatId: number): Promise<any[]> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    const result = await this.client.invoke({
+      _: 'getChatInviteLinks',
+      chat_id: chatId,
+      creator_user_id: (await this.client.invoke({ _: 'getMe' })).id,
+      is_revoked: false,
+      limit: 50,
+    }) as { invite_links?: any[] };
+    return result.invite_links || [];
+  }
+
+  async editChatInviteLink(chatId: number, inviteLink: string, expireDate?: number, memberLimit?: number): Promise<any> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    const params: Record<string, unknown> = { _: 'editChatInviteLink', chat_id: chatId, invite_link: inviteLink };
+    if (expireDate !== undefined) params.expire_date = expireDate;
+    if (memberLimit !== undefined) params.member_limit = memberLimit;
+    return await this.client.invoke(params);
+  }
+
+  async revokeChatInviteLink(chatId: number, inviteLink: string): Promise<any> {
+    if (!this._ready) throw new Error('Client not ready yet');
+    return await this.client.invoke({
+      _: 'revokeChatInviteLink',
+      chat_id: chatId,
+      invite_link: inviteLink,
+    });
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────
+
+  private async _resolveChatMembers(members: any[]): Promise<any[]> {
+    return Promise.all(members.map(async (m) => {
+      const sender = m.member_id || { _: 'messageSenderUser', user_id: 0 };
+      const userInfo = await this.resolver.resolveSender(sender);
+      const status = m.status?._?.replace('chatMemberStatus', '') || 'member';
+      return {
+        user_id: sender.user_id || sender.chat_id || 0,
+        name: userInfo?.name || 'Unknown',
+        status,
+        joined_date: m.joined_chat_date,
+      };
+    }));
+  }
+
   // Test accessors that delegate to sub-modules
   _extractText(content: any) { return extractText(content); }
   _formatMessage(msg: any, cache?: any) { return this.formatter.format(msg, cache); }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,8 @@
 import * as tdl from 'tdl';
 import * as dotenv from 'dotenv';
 import path from 'path';
+
+
 import type { RawTdChat, RawTdMessage, GroupInfo, ChatInfo, FormattedMessage } from './types';
 import { initTdlibModule, getResolvedTdlibPath } from './tdlib';
 import { AuthManager } from './auth';
@@ -358,12 +360,14 @@ export class TelegramLSPClient {
     const chat = await this.getRawChat(chatId);
     let memberCount = 0;
     let description = '';
+    let defaultRestricted = false;
     try {
       if (chat.type._ === 'chatTypeSupergroup') {
         const sg = await this.client.invoke({ _: 'getSupergroup', supergroup_id: chat.type.supergroup_id }) as { member_count: number };
         memberCount = sg.member_count;
-        const info = await this.client.invoke({ _: 'getSupergroupFullInfo', supergroup_id: chat.type.supergroup_id }) as { description?: string };
+        const info = await this.client.invoke({ _: 'getSupergroupFullInfo', supergroup_id: chat.type.supergroup_id }) as any;
         description = info.description || '';
+        defaultRestricted = info.member_permissions?.can_send_basic_messages === false;
       } else if (chat.type._ === 'chatTypeBasicGroup') {
         const bg = await this.client.invoke({ _: 'getBasicGroup', basic_group_id: chat.type.basic_group_id }) as { member_count: number };
         memberCount = bg.member_count;
@@ -378,6 +382,7 @@ export class TelegramLSPClient {
       onlineMemberCount: chat.online_member_count || 0,
       memberCount,
       description,
+      defaultRestricted,
     };
   }
 
@@ -651,21 +656,32 @@ export class TelegramLSPClient {
 
   async setChatDefaultPermissions(chatId: number, permissions: Record<string, boolean>): Promise<{ ok: boolean }> {
     if (!this._ready) throw new Error('Client not ready yet');
-    await this.client.invoke({
-      _: 'setChatPermissions',
-      chat_id: chatId,
-      permissions: { _: 'chatPermissions', ...permissions },
-    });
-    return { ok: true };
-  }
-
-  async setChatSlowModeDelay(chatId: number, delaySeconds: number): Promise<{ ok: boolean }> {
-    if (!this._ready) throw new Error('Client not ready yet');
-    await this.client.invoke({
-      _: 'setChatSlowModeDelay',
-      chat_id: chatId,
-      slow_mode_delay: delaySeconds,
-    });
+    const allow = permissions.can_send_messages;
+    const perms: Record<string, unknown> = { _: 'chatPermissions' };
+    if (allow) {
+      perms.can_send_basic_messages = true;
+      perms.can_send_audios = true;
+      perms.can_send_documents = true;
+      perms.can_send_photos = true;
+      perms.can_send_videos = true;
+      perms.can_send_video_notes = true;
+      perms.can_send_voice_notes = true;
+      perms.can_send_polls = true;
+      perms.can_send_other_messages = true;
+      perms.can_add_link_previews = true;
+    } else {
+      perms.can_send_basic_messages = false;
+      perms.can_send_audios = false;
+      perms.can_send_documents = false;
+      perms.can_send_photos = false;
+      perms.can_send_videos = false;
+      perms.can_send_video_notes = false;
+      perms.can_send_voice_notes = false;
+      perms.can_send_polls = false;
+      perms.can_send_other_messages = false;
+      perms.can_add_link_previews = false;
+    }
+    await this.client.invoke({ _: 'setChatPermissions', chat_id: chatId, permissions: perms });
     return { ok: true };
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -741,11 +741,13 @@ export class TelegramLSPClient {
 
   // ─── Permissions ─────────────────────────────────────────────────────
 
-  async getMyPermissions(chatId: number): Promise<Record<string, boolean>> {
+  async getMyPermissions(chatId: number): Promise<Record<string, unknown>> {
     if (!this._ready) return {};
     try {
       const chat = await this.getRawChat(chatId);
-      const perms: Record<string, boolean> = {
+      const me = await this.client.invoke({ _: 'getMe' }) as { id: number };
+      const perms: Record<string, unknown> = {
+        my_user_id: me.id,
         is_owner: false,
         is_admin: false,
         can_restrict_members: false,
@@ -762,7 +764,14 @@ export class TelegramLSPClient {
         const s = sg.status;
         if (s._ === 'chatMemberStatusCreator') {
           perms.is_owner = true;
-          for (const k of Object.keys(perms)) perms[k] = true;
+          perms.is_admin = true;
+          perms.can_restrict_members = true;
+          perms.can_promote_members = true;
+          perms.can_change_info = true;
+          perms.can_pin_messages = true;
+          perms.can_invite_users = true;
+          perms.can_delete_messages = true;
+          perms.can_manage_chat = true;
         } else if (s._ === 'chatMemberStatusAdministrator') {
           perms.is_admin = true;
           perms.can_restrict_members = !!s.can_restrict_members;
@@ -778,7 +787,14 @@ export class TelegramLSPClient {
         const s = bg.status;
         if (s._ === 'chatMemberStatusCreator') {
           perms.is_owner = true;
-          for (const k of Object.keys(perms)) perms[k] = true;
+          perms.is_admin = true;
+          perms.can_restrict_members = true;
+          perms.can_promote_members = true;
+          perms.can_change_info = true;
+          perms.can_pin_messages = true;
+          perms.can_invite_users = true;
+          perms.can_delete_messages = true;
+          perms.can_manage_chat = true;
         } else if (s._ === 'chatMemberStatusAdministrator') {
           perms.is_admin = true;
           perms.can_restrict_members = true;

--- a/src/client.ts
+++ b/src/client.ts
@@ -128,7 +128,9 @@ export class TelegramLSPClient {
 
   async getChats(force?: boolean): Promise<RawTdChat[]> {
     if (!this._ready) throw new Error('Client not ready yet');
-    if (this._chatsLoaded && !force) return [...this._chats.values()];
+    if (!force && this._chatsLoaded) return [...this._chats.values()];
+    this._chats.clear();
+    this._chatsLoaded = false;
 
     let offsetOrder = '9223372036854775807';
     let offsetChatId = 0;
@@ -230,7 +232,7 @@ export class TelegramLSPClient {
   }
 
   async getAllChats(): Promise<ChatInfo[]> {
-    const chats = await this.getChats();
+    const chats = await this.getChats(true);
     const results = chats.map(async (chat) => {
       const t = chat.type._;
       if (t === 'chatTypeBasicGroup' || (t === 'chatTypeSupergroup' && !chat.type.is_channel)) {
@@ -288,7 +290,7 @@ export class TelegramLSPClient {
   }
 
   async getGroups(): Promise<GroupInfo[]> {
-    const chats = await this.getChats();
+    const chats = await this.getChats(true);
     const groups = chats.filter((c) => {
       const t = c.type._;
       if (t === 'chatTypeBasicGroup') return true;

--- a/src/client.ts
+++ b/src/client.ts
@@ -360,18 +360,19 @@ export class TelegramLSPClient {
     const chat = await this.getRawChat(chatId);
     let memberCount = 0;
     let description = '';
-    let defaultRestricted = false;
+    const chatObj = chat as any;
+    const chatPerms = chatObj.permissions as Record<string, unknown> | undefined;
+    const defaultRestricted = chatPerms?.can_send_basic_messages === false;
     try {
       if (chat.type._ === 'chatTypeSupergroup') {
         const sg = await this.client.invoke({ _: 'getSupergroup', supergroup_id: chat.type.supergroup_id }) as { member_count: number };
         memberCount = sg.member_count;
         const info = await this.client.invoke({ _: 'getSupergroupFullInfo', supergroup_id: chat.type.supergroup_id }) as any;
         description = info.description || '';
-        defaultRestricted = info.member_permissions?.can_send_basic_messages === false;
       } else if (chat.type._ === 'chatTypeBasicGroup') {
         const bg = await this.client.invoke({ _: 'getBasicGroup', basic_group_id: chat.type.basic_group_id }) as { member_count: number };
         memberCount = bg.member_count;
-        const info = await this.client.invoke({ _: 'getBasicGroupFullInfo', basic_group_id: chat.type.basic_group_id }) as { description?: string };
+        const info = await this.client.invoke({ _: 'getBasicGroupFullInfo', basic_group_id: chat.type.basic_group_id }) as any;
         description = info.description || '';
       }
     } catch (e) { console.warn('getChatInfo member count failed:', (e as Error).message); }

--- a/src/client.ts
+++ b/src/client.ts
@@ -357,13 +357,18 @@ export class TelegramLSPClient {
     if (!this._ready) throw new Error('Client not ready yet');
     const chat = await this.getRawChat(chatId);
     let memberCount = 0;
+    let description = '';
     try {
       if (chat.type._ === 'chatTypeSupergroup') {
         const sg = await this.client.invoke({ _: 'getSupergroup', supergroup_id: chat.type.supergroup_id }) as { member_count: number };
         memberCount = sg.member_count;
+        const info = await this.client.invoke({ _: 'getSupergroupFullInfo', supergroup_id: chat.type.supergroup_id }) as { description?: string };
+        description = info.description || '';
       } else if (chat.type._ === 'chatTypeBasicGroup') {
         const bg = await this.client.invoke({ _: 'getBasicGroup', basic_group_id: chat.type.basic_group_id }) as { member_count: number };
         memberCount = bg.member_count;
+        const info = await this.client.invoke({ _: 'getBasicGroupFullInfo', basic_group_id: chat.type.basic_group_id }) as { description?: string };
+        description = info.description || '';
       }
     } catch (e) { console.warn('getChatInfo member count failed:', (e as Error).message); }
     return {
@@ -372,6 +377,7 @@ export class TelegramLSPClient {
       unreadCount: chat.unread_count || 0,
       onlineMemberCount: chat.online_member_count || 0,
       memberCount,
+      description,
     };
   }
 
@@ -643,15 +649,6 @@ export class TelegramLSPClient {
     return this._resolveChatMembers(result.members || []);
   }
 
-  async getChatAdministrators(chatId: number): Promise<any[]> {
-    if (!this._ready) throw new Error('Client not ready yet');
-    const result = await this.client.invoke({
-      _: 'getChatAdministrators',
-      chat_id: chatId,
-    }) as any[];
-    return this._resolveChatMembers(result || []);
-  }
-
   async setChatDefaultPermissions(chatId: number, permissions: Record<string, boolean>): Promise<{ ok: boolean }> {
     if (!this._ready) throw new Error('Client not ready yet');
     await this.client.invoke({
@@ -740,6 +737,64 @@ export class TelegramLSPClient {
       chat_id: chatId,
       invite_link: inviteLink,
     });
+  }
+
+  // ─── Permissions ─────────────────────────────────────────────────────
+
+  async getMyPermissions(chatId: number): Promise<Record<string, boolean>> {
+    if (!this._ready) return {};
+    try {
+      const chat = await this.getRawChat(chatId);
+      const perms: Record<string, boolean> = {
+        is_owner: false,
+        is_admin: false,
+        can_restrict_members: false,
+        can_promote_members: false,
+        can_change_info: false,
+        can_pin_messages: false,
+        can_invite_users: false,
+        can_delete_messages: false,
+        can_manage_chat: false,
+      };
+
+      if (chat.type._ === 'chatTypeSupergroup') {
+        const sg: any = await this.client.invoke({ _: 'getSupergroup', supergroup_id: chat.type.supergroup_id });
+        const s = sg.status;
+        if (s._ === 'chatMemberStatusCreator') {
+          perms.is_owner = true;
+          for (const k of Object.keys(perms)) perms[k] = true;
+        } else if (s._ === 'chatMemberStatusAdministrator') {
+          perms.is_admin = true;
+          perms.can_restrict_members = !!s.can_restrict_members;
+          perms.can_promote_members = !!s.can_promote_members;
+          perms.can_change_info = !!s.can_change_info;
+          perms.can_pin_messages = !!s.can_pin_messages;
+          perms.can_invite_users = !!s.can_invite_users;
+          perms.can_delete_messages = !!s.can_delete_messages;
+          perms.can_manage_chat = !!s.can_manage_chat;
+        }
+      } else if (chat.type._ === 'chatTypeBasicGroup') {
+        const bg: any = await this.client.invoke({ _: 'getBasicGroup', basic_group_id: chat.type.basic_group_id });
+        const s = bg.status;
+        if (s._ === 'chatMemberStatusCreator') {
+          perms.is_owner = true;
+          for (const k of Object.keys(perms)) perms[k] = true;
+        } else if (s._ === 'chatMemberStatusAdministrator') {
+          perms.is_admin = true;
+          perms.can_restrict_members = true;
+          perms.can_promote_members = true;
+          perms.can_change_info = true;
+          perms.can_invite_users = true;
+          perms.can_delete_messages = true;
+          perms.can_manage_chat = true;
+        }
+      }
+
+      return perms;
+    } catch (e) {
+      console.warn('getMyPermissions failed:', (e as Error).message);
+      return {};
+    }
   }
 
   // ─── Helpers ────────────────────────────────────────────────────────

--- a/src/format.ts
+++ b/src/format.ts
@@ -46,6 +46,8 @@ export class MessageFormatter {
       );
     }
 
+    if (msg.views) formatted.views = msg.views;
+
     const replyTo = await this._formatReplyTo(msg);
     if (replyTo) formatted.replyTo = replyTo;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -376,15 +376,6 @@ app.post('/chat/set-permissions', async (req, res) => {
   } catch (err) { res.status(500).json({ error: (err as Error).message }); }
 });
 
-app.post('/chat/set-slow-mode', async (req, res) => {
-  try {
-    const { chatId, delaySeconds } = req.body;
-    if (!chatId || delaySeconds === undefined) { res.status(400).json({ error: 'chatId and delaySeconds are required' }); return; }
-    const result = await tgClient.setChatSlowModeDelay(Number(chatId), Number(delaySeconds));
-    res.json(result);
-  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
-});
-
 // ─── Group Settings ────────────────────────────────────────────────────
 
 app.post('/chat/set-title', async (req, res) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -349,20 +349,20 @@ app.post('/chat/add-member', async (req, res) => {
   } catch (err) { res.status(500).json({ error: (err as Error).message }); }
 });
 
+app.get('/chat/my-permissions', async (req, res) => {
+  try {
+    const { chatId } = req.query;
+    if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
+    const result = await tgClient.getMyPermissions(Number(chatId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
 app.get('/chat/members', async (req, res) => {
   try {
     const { chatId } = req.query;
     if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
     const result = await tgClient.searchChatMembers(Number(chatId));
-    res.json({ members: result });
-  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
-});
-
-app.get('/chat/admins', async (req, res) => {
-  try {
-    const { chatId } = req.query;
-    if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
-    const result = await tgClient.getChatAdministrators(Number(chatId));
     res.json({ members: result });
   } catch (err) { res.status(500).json({ error: (err as Error).message }); }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -284,6 +284,183 @@ app.post('/forwardMessages', async (req, res) => {
   }
 });
 
+// ─── Member Management ────────────────────────────────────────────────
+
+app.post('/chat/ban', async (req, res) => {
+  try {
+    const { chatId, userId } = req.body;
+    if (!chatId || !userId) { res.status(400).json({ error: 'chatId and userId are required' }); return; }
+    const result = await tgClient.banChatMember(Number(chatId), Number(userId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/unban', async (req, res) => {
+  try {
+    const { chatId, userId } = req.body;
+    if (!chatId || !userId) { res.status(400).json({ error: 'chatId and userId are required' }); return; }
+    const result = await tgClient.unbanChatMember(Number(chatId), Number(userId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/promote', async (req, res) => {
+  try {
+    const { chatId, userId } = req.body;
+    if (!chatId || !userId) { res.status(400).json({ error: 'chatId and userId are required' }); return; }
+    const result = await tgClient.promoteChatMember(Number(chatId), Number(userId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/demote', async (req, res) => {
+  try {
+    const { chatId, userId } = req.body;
+    if (!chatId || !userId) { res.status(400).json({ error: 'chatId and userId are required' }); return; }
+    const result = await tgClient.demoteChatMember(Number(chatId), Number(userId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/restrict', async (req, res) => {
+  try {
+    const { chatId, userId, untilDate } = req.body;
+    if (!chatId || !userId) { res.status(400).json({ error: 'chatId and userId are required' }); return; }
+    const result = await tgClient.restrictChatMember(Number(chatId), Number(userId), untilDate ? Number(untilDate) : 0);
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/unrestrict', async (req, res) => {
+  try {
+    const { chatId, userId } = req.body;
+    if (!chatId || !userId) { res.status(400).json({ error: 'chatId and userId are required' }); return; }
+    const result = await tgClient.unrestrictChatMember(Number(chatId), Number(userId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/add-member', async (req, res) => {
+  try {
+    const { chatId, userId } = req.body;
+    if (!chatId || !userId) { res.status(400).json({ error: 'chatId and userId are required' }); return; }
+    const result = await tgClient.addChatMember(Number(chatId), Number(userId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.get('/chat/members', async (req, res) => {
+  try {
+    const { chatId } = req.query;
+    if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
+    const result = await tgClient.searchChatMembers(Number(chatId));
+    res.json({ members: result });
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.get('/chat/admins', async (req, res) => {
+  try {
+    const { chatId } = req.query;
+    if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
+    const result = await tgClient.getChatAdministrators(Number(chatId));
+    res.json({ members: result });
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/set-permissions', async (req, res) => {
+  try {
+    const { chatId, permissions } = req.body;
+    if (!chatId || !permissions) { res.status(400).json({ error: 'chatId and permissions are required' }); return; }
+    const result = await tgClient.setChatDefaultPermissions(Number(chatId), permissions);
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/set-slow-mode', async (req, res) => {
+  try {
+    const { chatId, delaySeconds } = req.body;
+    if (!chatId || delaySeconds === undefined) { res.status(400).json({ error: 'chatId and delaySeconds are required' }); return; }
+    const result = await tgClient.setChatSlowModeDelay(Number(chatId), Number(delaySeconds));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+// ─── Group Settings ────────────────────────────────────────────────────
+
+app.post('/chat/set-title', async (req, res) => {
+  try {
+    const { chatId, title } = req.body;
+    if (!chatId || !title) { res.status(400).json({ error: 'chatId and title are required' }); return; }
+    const result = await tgClient.setChatTitle(Number(chatId), title);
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/set-description', async (req, res) => {
+  try {
+    const { chatId, description } = req.body;
+    if (!chatId || description === undefined) { res.status(400).json({ error: 'chatId and description are required' }); return; }
+    const result = await tgClient.setChatDescription(Number(chatId), description);
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/leave', async (req, res) => {
+  try {
+    const { chatId } = req.body;
+    if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
+    const result = await tgClient.leaveChat(Number(chatId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/delete-history', async (req, res) => {
+  try {
+    const { chatId } = req.body;
+    if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
+    const result = await tgClient.deleteChatHistory(Number(chatId));
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+// ─── Invite Links ──────────────────────────────────────────────────────
+
+app.post('/chat/create-invite-link', async (req, res) => {
+  try {
+    const { chatId, expireDate, memberLimit } = req.body;
+    if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
+    const result = await tgClient.createChatInviteLink(Number(chatId), expireDate ? Number(expireDate) : undefined, memberLimit ? Number(memberLimit) : undefined);
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.get('/chat/invite-links', async (req, res) => {
+  try {
+    const { chatId } = req.query;
+    if (!chatId) { res.status(400).json({ error: 'chatId is required' }); return; }
+    const result = await tgClient.getChatInviteLinks(Number(chatId));
+    res.json({ invite_links: result });
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/edit-invite-link', async (req, res) => {
+  try {
+    const { chatId, inviteLink, expireDate, memberLimit } = req.body;
+    if (!chatId || !inviteLink) { res.status(400).json({ error: 'chatId and inviteLink are required' }); return; }
+    const result = await tgClient.editChatInviteLink(Number(chatId), inviteLink, expireDate ? Number(expireDate) : undefined, memberLimit ? Number(memberLimit) : undefined);
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
+app.post('/chat/revoke-invite-link', async (req, res) => {
+  try {
+    const { chatId, inviteLink } = req.body;
+    if (!chatId || !inviteLink) { res.status(400).json({ error: 'chatId and inviteLink are required' }); return; }
+    const result = await tgClient.revokeChatInviteLink(Number(chatId), inviteLink);
+    res.json(result);
+  } catch (err) { res.status(500).json({ error: (err as Error).message }); }
+});
+
 app.get('/messageMedia', async (req, res) => {
   try {
     const { chatId, messageId } = req.query;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface FormattedMessage {
   filePath?: string;
   mediaPath?: string;
   mimeType?: string;
+  views?: number;
 }
 
 export interface RawTdMessage {
@@ -43,6 +44,7 @@ export interface RawTdMessage {
     origin_sender_name?: string;
     chat_id?: number;
   } | null;
+  views?: number;
 }
 
 export interface RawTdChat {
@@ -75,7 +77,7 @@ export interface GroupInfo {
 export interface ChatInfo {
   id: number;
   title: string;
-  type: 'group' | 'private';
+  type: 'group' | 'private' | 'channel';
   unreadCount: number;
   onlineMemberCount: number;
   lastMessage?: FormattedMessage | null;

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -17,6 +17,7 @@ export class UpdateDispatcher {
       switch (update._) {
         case 'updateNewChat':
           this.chats.set((update.chat as RawTdChat).id, update.chat as RawTdChat);
+          this.broadcastRaw(update);
           break;
         case 'updateNewMessage':
           await this.handleNewMessage(update.message as RawTdMessage);

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -51,8 +51,14 @@ export class UpdateDispatcher {
         case 'updateChatUnreadMentionCount':
           this.handleChatUnreadMentionCount(update);
           break;
+        case 'updateChatTitle':
+          this.handleChatTitle(update);
+          break;
+        case 'updateChatPermissions':
+          this.handleChatPermissions(update);
+          break;
         default:
-          console.log(update);
+          this.broadcastRaw(update);
       }
     });
   }
@@ -205,6 +211,34 @@ export class UpdateDispatcher {
       last_read_inbox_message_id: update.last_read_inbox_message_id,
       unread_count: update.unread_count,
     });
+  }
+
+  handleChatTitle(update: TdUpdate) {
+    const broadcast = this.getBroadcast();
+    if (typeof broadcast !== 'function') return;
+    broadcast({
+      event: 'chatTitle',
+      chat_id: update.chat_id,
+      title: update.title,
+    });
+  }
+
+  handleChatPermissions(update: TdUpdate) {
+    const broadcast = this.getBroadcast();
+    if (typeof broadcast !== 'function') return;
+    const perms = (update as any).permissions as Record<string, unknown> | undefined;
+    broadcast({
+      event: 'chatPermissions',
+      chat_id: update.chat_id,
+      default_restricted: perms?.can_send_basic_messages === false,
+    });
+  }
+
+  broadcastRaw(update: TdUpdate) {
+    const broadcast = this.getBroadcast();
+    if (typeof broadcast !== 'function') return;
+    const event = update._.replace(/^update/, '');
+    broadcast({ event, ...update });
   }
 
   handleChatUnreadMentionCount(update: TdUpdate) {


### PR DESCRIPTION
## Summary
- Channel support: channels appear in chat list with `#` prefix, message views displayed, admin tools available based on permissions
- Group management: member list (ban/unban/promote/demote), invite links, group settings (title, description, permissions, leave)
- Async HTTP: all blocking HTTP calls replaced with async (vim.net.request primary, curl fallback), search is non-blocking
- Send permission: `@send` tool and `i` key respect `can_send_messages` permission
- Event sync: NewChat/chatMember/ChatPosition events sync group list; chat removal on kick/leave/banned properly handled
- Stale messages fix: buffer cleared immediately when switching chats