### PR TITLE
chore(gitignore): add *.txt and *.py to ignored patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tdlib_db/
 tdlib_files/
 tg: *
 Thumbs.db
+*.txt
+*.py

--- a/lua/telegram/config.lua
+++ b/lua/telegram/config.lua
@@ -78,6 +78,8 @@ function M.setup(opts)
 	vim.api.nvim_set_hl(0, "TgPermToggle", { fg = hl_fg("DiagnosticInfo"), bold = true, default = true })
 	local border_fg = hl_fg("FloatBorder")
 	vim.api.nvim_set_hl(0, "TgBorder", { fg = border_fg, bg = "NONE", default = true })
+	vim.api.nvim_set_hl(0, "TgDateSeparator", { fg = comment_fg, default = true })
+	vim.api.nvim_set_hl(0, "TgUnreadDivider", { fg = hl_fg("DiagnosticInfo") or "#89b4fa", bold = true, default = true })
 end
 
 M.plugin_root = plugin_root

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -433,9 +433,10 @@ local function finish_init()
 				end
 			end)
 		elseif msg.event == "chatReadInbox" then
+			local server_count = msg.unread_count or 0
+			local server_last = msg.last_read_inbox_message_id
 			vim.schedule(function()
 				if msg.chat_id and ui.state.groups[msg.chat_id] then
-					local server_count = msg.unread_count or 0
 					if server_count > (ui.state.groups[msg.chat_id].unread_count or 0) then
 						ui.state.groups[msg.chat_id].unread_count = server_count
 					end
@@ -444,6 +445,10 @@ local function finish_init()
 							ui.state.unread = server_count
 						end
 						ui.update_title()
+					end
+					if server_last and server_last > 0 then
+						ui.state.saved_last_read = ui.state.saved_last_read or {}
+						ui.state.saved_last_read[msg.chat_id] = server_last
 					end
 					debounced_redraw()
 				end

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -210,6 +210,7 @@ local function flush_msg_queue()
 					filePath = msg.filePath,
 					mediaPath = msg.mediaPath,
 					mimeType = msg.mimeType,
+					_unread = not msg.own,
 				})
 			else
 				st.exhausted_forward = false

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -435,9 +435,11 @@ local function finish_init()
 		elseif msg.event == "chatReadInbox" then
 			vim.schedule(function()
 				if msg.chat_id and ui.state.groups[msg.chat_id] then
-					ui.state.groups[msg.chat_id].unread_count = msg.unread_count or 0
+					local server_count = msg.unread_count or 0
+					if server_count > (ui.state.groups[msg.chat_id].unread_count or 0) then
+						ui.state.groups[msg.chat_id].unread_count = server_count
+					end
 					if msg.chat_id == ui.state.chat_id then
-						local server_count = msg.unread_count or 0
 						if server_count > ui.state.unread then
 							ui.state.unread = server_count
 						end

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -185,7 +185,10 @@ local function flush_msg_queue()
 		end
 
 		if not skip_insert then
-			st.unread = st.unread + 1
+			local should_count_unread = not msg.own and not at_bottom
+			if should_count_unread then
+				st.unread = st.unread + 1
+			end
 			if st.groups[st.chat_id] then
 				st.groups[st.chat_id].unread_count = st.unread
 			end
@@ -210,7 +213,7 @@ local function flush_msg_queue()
 					filePath = msg.filePath,
 					mediaPath = msg.mediaPath,
 					mimeType = msg.mimeType,
-					_unread = not msg.own and not at_bottom,
+					_unread = should_count_unread,
 				})
 			else
 				st.exhausted_forward = false
@@ -437,12 +440,13 @@ local function finish_init()
 			local server_last = msg.last_read_inbox_message_id
 			vim.schedule(function()
 				if msg.chat_id and ui.state.groups[msg.chat_id] then
-					if server_count > (ui.state.groups[msg.chat_id].unread_count or 0) then
-						ui.state.groups[msg.chat_id].unread_count = server_count
-					end
+					ui.state.groups[msg.chat_id].unread_count = server_count
 					if msg.chat_id == ui.state.chat_id then
-						if server_count > ui.state.unread then
-							ui.state.unread = server_count
+						ui.state.unread = math.min(server_count, ui.state.unread)
+						if server_last and server_last > 0 then
+							if (ui.state.last_read_id or 0) < server_last then
+								ui.state.last_read_id = server_last
+							end
 						end
 						ui.update_title()
 					end

--- a/lua/telegram/init.lua
+++ b/lua/telegram/init.lua
@@ -210,7 +210,7 @@ local function flush_msg_queue()
 					filePath = msg.filePath,
 					mediaPath = msg.mediaPath,
 					mimeType = msg.mimeType,
-					_unread = not msg.own,
+					_unread = not msg.own and not at_bottom,
 				})
 			else
 				st.exhausted_forward = false
@@ -437,7 +437,10 @@ local function finish_init()
 				if msg.chat_id and ui.state.groups[msg.chat_id] then
 					ui.state.groups[msg.chat_id].unread_count = msg.unread_count or 0
 					if msg.chat_id == ui.state.chat_id then
-						ui.state.unread = msg.unread_count or 0
+						local server_count = msg.unread_count or 0
+						if server_count > ui.state.unread then
+							ui.state.unread = server_count
+						end
 						ui.update_title()
 					end
 					debounced_redraw()

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -822,6 +822,7 @@ function M.open_chat(chat_id, chat_title, chat_type)
 		if state.chat_id ~= cid then return end
 		if chat_info then
 			chat_info_holder = chat_info
+			state.last_read_id = chat_info.lastReadInboxMessageId or 0
 			if chat_info.onlineMemberCount and chat_info.onlineMemberCount > 0 then
 				state.online_count = chat_info.onlineMemberCount
 			end
@@ -876,6 +877,8 @@ function M.destroy_chat()
 	state._pending_edit = nil
 	state.msg_line_counts = {}
 	state.extra_before = {}
+	state.last_read_id = nil
+	state._unread_start = nil
 	state.loading = false
 	state.exhausted = false
 	state.exhausted_forward = false
@@ -1014,6 +1017,13 @@ function M.load_newer()
 				if a.date ~= b.date then return a.date < b.date end
 				return a.id < b.id
 			end)
+			if state.last_read_id and state.last_read_id > 0 then
+				for _, m in ipairs(new_msgs) do
+					if m.id > state.last_read_id and not m.own then
+						m._unread = true
+					end
+				end
+			end
 			st.trim_oldest()
 			render()
 		end

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -150,7 +150,16 @@ local function render()
 	local extra_before = {}
 	local extra_count = 0
 	local prev_date_key = nil
-	local unread_idx = state.unread > 0 and (#state.messages - state.unread + 1) or nil
+	local unread_idx = nil
+	if state.unread > 0 then
+		if state._unread_start then
+			unread_idx = state._unread_start
+		else
+			for i, m in ipairs(state.messages) do
+				if m._unread then unread_idx = i; break end
+			end
+		end
+	end
 	for i, msg in ipairs(state.messages) do
 		local date_key = os.date("%Y%m%d", msg.date)
 		if prev_date_key and date_key ~= prev_date_key then
@@ -582,18 +591,21 @@ function M.open_chat(chat_id, chat_title, chat_type)
 				end
 				local total_lines = vim.api.nvim_buf_line_count(state.buf)
 				if state.unread > 0 then
-					local first_unread_idx = #state.messages - state.unread + 1
-					if first_unread_idx >= 1 and first_unread_idx <= #state.messages then
-						local first_unread_line = line_of(state.messages[first_unread_idx].id)
-						if first_unread_line and cursor_line >= first_unread_line then
-							state.unread = 0
-							if state.chat_id and state.groups[state.chat_id] then
-								state.groups[state.chat_id].unread_count = 0
-								state.groups[state.chat_id].mention_count = 0
+					local current_idx = M.message_at_cursor()
+					if current_idx then
+						local last_read_id = nil
+						for i = 1, current_idx - 1 do
+							local m = state.messages[i]
+							if m._unread then
+								m._unread = nil
+								state.unread = math.max(0, state.unread - 1)
+								last_read_id = m.id
 							end
-							local latest = state.messages[#state.messages]
-							if latest then
-								server.view_messages(state.chat_id, latest.id)
+						end
+						if last_read_id then
+							server.view_messages(state.chat_id, last_read_id)
+							if state.chat_id and state.groups[state.chat_id] then
+								state.groups[state.chat_id].unread_count = state.unread
 							end
 						end
 					end
@@ -728,20 +740,22 @@ function M.open_chat(chat_id, chat_title, chat_type)
 	local pending = 2
 	local function check_done()
 		pending = pending - 1
-		local function position_at_first_unread()
-			local first_unread_idx = nil
+		local function count_unread()
 			local last_read = chat_info_holder and chat_info_holder.lastReadInboxMessageId or 0
 			local unread_count = 0
+			local first_unread_idx
 			for i, m in ipairs(state.messages) do
-				if last_read > 0 and m.id > last_read then
+				if last_read > 0 and m.id > last_read and not m.own then
+					m._unread = true
 					unread_count = unread_count + 1
 					if not first_unread_idx then first_unread_idx = i end
+				else
+					m._unread = nil
 				end
 			end
 			state.unread = unread_count
-			local target_idx = first_unread_idx or #state.messages
-			local l = line_of(state.messages[target_idx].id)
-			if l then pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 }) end
+			state._unread_start = first_unread_idx
+			return first_unread_idx
 		end
 
 		if pending == 0 then
@@ -758,12 +772,12 @@ function M.open_chat(chat_id, chat_title, chat_type)
 							if a.date ~= b.date then return a.date < b.date end
 							return a.id < b.id
 						end)
+						local first_unread_idx = count_unread()
 						render()
 						title.update_title()
-						if #state.messages > 0 then
-							server.view_messages(state.chat_id, state.messages[#state.messages].id)
-						end
-						position_at_first_unread()
+						local target_idx = first_unread_idx or #state.messages
+						local l = line_of(state.messages[target_idx].id)
+						if l then pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 }) end
 					end
 				end)
 			elseif chat_info_holder and chat_info_holder.unreadCount
@@ -781,12 +795,12 @@ function M.open_chat(chat_id, chat_title, chat_type)
 							if a.date ~= b.date then return a.date < b.date end
 							return a.id < b.id
 						end)
+						local first_unread_idx = count_unread()
 						render()
 						title.update_title()
-						if #state.messages > 0 then
-							server.view_messages(state.chat_id, state.messages[#state.messages].id)
-						end
-						position_at_first_unread()
+						local target_idx = first_unread_idx or #state.messages
+						local l = line_of(state.messages[target_idx].id)
+						if l then pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 }) end
 					end
 				end)
 			else
@@ -795,7 +809,11 @@ function M.open_chat(chat_id, chat_title, chat_type)
 				state.exhausted_forward = false
 				render()
 				M.refresh_messages(function()
-					position_at_first_unread()
+					local first_unread_idx = count_unread()
+					render()
+					local target_idx = first_unread_idx or #state.messages
+					local l = line_of(state.messages[target_idx].id)
+					if l then pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 }) end
 				end)
 			end
 		end
@@ -1038,7 +1056,6 @@ function M.refresh_messages(on_complete)
 			local latest = state.messages[#state.messages]
 			local ts = os.date("%Y-%m-%d %H:%M", latest.date)
 			state.last_msg = "[" .. ts .. "] " .. (latest.sender and latest.sender.name or "?") .. ": " .. (latest.text or "")
-			server.view_messages(state.chat_id, latest.id)
 		end
 		if on_complete then on_complete() end
 	end, function(err)

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -31,7 +31,7 @@ local function line_of(target_id)
 	local line_counts = state.msg_line_counts
 	for i, m in ipairs(state.messages) do
 		if m.id == target_id then
-			local line = 1 + off
+			local line = 1 + off + (state.extra_before[i] or 0)
 			for j = 1, i - 1 do
 				line = line + (line_counts[j] or #fmt_msg(state.messages[j]))
 			end
@@ -50,8 +50,13 @@ local function apply_highlights()
 	vim.api.nvim_buf_clear_namespace(buf, st.target_ns, 0, -1)
 	for l = 0, vim.api.nvim_buf_line_count(buf) - 1 do
 		local line = vim.api.nvim_buf_get_lines(buf, l, l + 1, false)[1]
-		if line and line:find("^%[[%+%-%~%*%>!]%]") then
+		if not line then
+		elseif line:find("^%[%+%-%~%*%>!]%]") then
 			pcall(vim.api.nvim_buf_add_highlight, buf, st.hl_ns, "TgService", l, 0, -1)
+		elseif line:find("^  ── .+ ──  $") then
+			pcall(vim.api.nvim_buf_add_highlight, buf, st.hl_ns, "TgDateSeparator", l, 0, -1)
+		elseif line:find("^── %d+ unread messages ──$") then
+			pcall(vim.api.nvim_buf_add_highlight, buf, st.hl_ns, "TgUnreadDivider", l, 0, -1)
 		end
 	end
 	local target_id = state.reply_to
@@ -76,6 +81,7 @@ local function apply_highlights()
 	local line = 1 + off
 	local line_counts = state.msg_line_counts
 	for i, m in ipairs(state.messages) do
+		line = line + (state.extra_before[i] or 0)
 		local n = line_counts[i] or #fmt_msg(m)
 		if m.id == target_id then
 			local start_line = line - 1
@@ -90,6 +96,28 @@ local function apply_highlights()
 			break
 		end
 		line = line + n
+	end
+end
+
+-- ─── Date separator formatting ──────────────────────────────────────────
+
+local weekday_names = { "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday" }
+local function format_date_separator(date_ts)
+	local t = os.date("*t", date_ts)
+	local now = os.date("*t")
+	local today = os.time({ year = now.year, month = now.month, day = now.day, hour = 0, min = 0, sec = 0 })
+	local msg_day = os.time({ year = t.year, month = t.month, day = t.day, hour = 0, min = 0, sec = 0 })
+	local diff = math.floor((today - msg_day) / 86400)
+	if diff == 0 then
+		return "  ── Today ──  "
+	elseif diff == 1 then
+		return "  ── Yesterday ──  "
+	elseif diff <= 7 and t.wday then
+		return "  ── " .. weekday_names[t.wday] .. " ──  "
+	elseif t.year == now.year then
+		return string.format("  ── %s %d ──  ", os.date("%B", date_ts), t.day)
+	else
+		return string.format("  ── %s %d, %d ──  ", os.date("%B", date_ts), t.day, t.year)
 	end
 end
 
@@ -119,7 +147,22 @@ local function render()
 	end
 	local lines = {}
 	local line_counts = {}
+	local extra_before = {}
+	local extra_count = 0
+	local prev_date_key = nil
+	local unread_idx = state.unread > 0 and (#state.messages - state.unread + 1) or nil
 	for i, msg in ipairs(state.messages) do
+		local date_key = os.date("%Y%m%d", msg.date)
+		if prev_date_key and date_key ~= prev_date_key then
+			table.insert(lines, format_date_separator(msg.date))
+			extra_count = extra_count + 1
+		end
+		prev_date_key = date_key
+		if unread_idx and i == unread_idx then
+			table.insert(lines, "── " .. state.unread .. " unread messages ──")
+			extra_count = extra_count + 1
+		end
+		extra_before[i] = extra_count
 		local msg_lines = fmt_msg(msg)
 		local n = #msg_lines
 		line_counts[i] = n
@@ -128,6 +171,7 @@ local function render()
 		end
 	end
 	state.msg_line_counts = line_counts
+	state.extra_before = extra_before
 	if state.title_win and vim.api.nvim_win_is_valid(state.title_win) then
 		state.title_height = vim.api.nvim_win_get_height(state.title_win)
 	end
@@ -564,10 +608,11 @@ function M.open_chat(chat_id, chat_title, chat_type)
 				end
 				state._scroll_timer = vim.fn.timer_start(50, function()
 					state._scroll_timer = nil
-					local line_counts = state.msg_line_counts
-					local l = min_line
-					for i, msg in ipairs(state.messages) do
-						local n = line_counts[i] or #fmt_msg(msg)
+				local line_counts = state.msg_line_counts
+				local l = min_line
+				for i, msg in ipairs(state.messages) do
+					l = l + (state.extra_before[i] or 0)
+					local n = line_counts[i] or #fmt_msg(msg)
 						if cursor_line >= l and cursor_line < l + n then
 							state.saved_cursors = state.saved_cursors or {}
 							state.saved_cursors[state.chat_id] = msg.id
@@ -730,23 +775,12 @@ function M.open_chat(chat_id, chat_title, chat_type)
 						if #state.messages > 0 then
 							server.view_messages(state.chat_id, state.messages[#state.messages].id)
 						end
-						local target = chat_info_holder.lastReadInboxMessageId
-						local scrolled = false
-						for i, m in ipairs(state.messages) do
-							if m.id == target then
-								local nxt = i + 1
-								if nxt <= #state.messages then
-									local l = line_of(state.messages[nxt].id)
-									if l then
-										pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
-										scrolled = true
-									end
-								end
-								break
+						local last = state.messages[#state.messages]
+						if last then
+							local l = line_of(last.id)
+							if l then
+								pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
 							end
-						end
-						if not scrolled then
-							M.jump_to_bottom()
 						end
 					end
 				end)
@@ -818,6 +852,7 @@ function M.destroy_chat()
 	state.messages = {}
 	state._pending_edit = nil
 	state.msg_line_counts = {}
+	state.extra_before = {}
 	state.loading = false
 	state.exhausted = false
 	state.exhausted_forward = false
@@ -849,6 +884,8 @@ function M.message_at_cursor()
 	local line_counts = state.msg_line_counts
 	local line = 1 + off
 	for idx, msg in ipairs(state.messages) do
+		local extra = state.extra_before[idx] or 0
+		line = line + extra
 		local n = line_counts[idx] or #fmt_msg(msg)
 		if cursor_line >= line and cursor_line < line + n then
 			return idx

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -775,9 +775,16 @@ function M.open_chat(chat_id, chat_title, chat_type)
 						if #state.messages > 0 then
 							server.view_messages(state.chat_id, state.messages[#state.messages].id)
 						end
-						local last = state.messages[#state.messages]
-						if last then
-							local l = line_of(last.id)
+						local target_id = chat_info_holder.lastReadInboxMessageId
+						local first_unread_idx = nil
+						for i, m in ipairs(state.messages) do
+							if m.id > target_id then
+								first_unread_idx = i
+								break
+							end
+						end
+						if first_unread_idx then
+							local l = line_of(state.messages[first_unread_idx].id)
 							if l then
 								pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
 							end
@@ -804,6 +811,7 @@ function M.open_chat(chat_id, chat_title, chat_type)
 			end
 			state.description = chat_info.description or ""
 			state.default_restricted = chat_info.defaultRestricted or false
+			state.unread = chat_info.unreadCount or 0
 			groups.refresh_pinned_message(cid, chat_info.pinnedMessageId)
 		end
 		check_done()

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -162,6 +162,16 @@ local function render()
 				if m._unread then unread_idx = i; break end
 			end
 		end
+	if #state.messages == 0 then
+		if state.loading then
+			table.insert(lines, "[~ Loading...]")
+		else
+			table.insert(lines, "[~ No messages yet]")
+		end
+	end
+	if state.loading and #state.messages > 0 then
+		table.insert(lines, "[~ Loading older messages...]")
+	end
 	end
 	for i, msg in ipairs(state.messages) do
 		local date_key = os.date("%Y%m%d", msg.date)
@@ -181,6 +191,9 @@ local function render()
 		for _, l in ipairs(msg_lines) do
 			table.insert(lines, l)
 		end
+	end
+	if state.loading_newer and #state.messages > 0 then
+		table.insert(lines, "[~ Loading newer messages...]")
 	end
 	state.msg_line_counts = line_counts
 	state.extra_before = extra_before
@@ -981,6 +994,7 @@ end
 function M.load_older()
 	if state.loading or state.exhausted or #state.messages == 0 then return end
 	state.loading = true
+	render()
 	local chat_id = state.chat_id
 	local oldest = state.messages[1]
 	local cursor_idx = M.message_at_cursor()
@@ -989,7 +1003,12 @@ function M.load_older()
 	server.get_messages_async(chat_id, server.DEFAULT_LIMIT, oldest.id, function(data)
 		if state.chat_id ~= chat_id then state.loading = false; return end
 		local new_msgs = data.messages or {}
-		if #new_msgs == 0 then state.exhausted = true; state.loading = false; return end
+		if #new_msgs == 0 then
+			state.exhausted = true
+			state.loading = false
+			render()
+			return
+		end
 		local added = false
 		local seen = {}
 		for _, m in ipairs(state.messages) do seen[tostring(m.id)] = true end
@@ -1007,6 +1026,7 @@ function M.load_older()
 				return a.id < b.id
 			end)
 			st.trim_newest()
+				state.loading = false
 			render()
 		end
 		if cursor_msg_id then
@@ -1022,12 +1042,18 @@ end
 function M.load_newer()
 	if state.loading_newer or state.exhausted_forward or #state.messages == 0 then return end
 	state.loading_newer = true
+	render()
 	local chat_id = state.chat_id
 	local newest = state.messages[#state.messages]
 	server.get_messages_after_async(chat_id, newest.id, server.DEFAULT_LIMIT, function(data)
 		if state.chat_id ~= chat_id then state.loading_newer = false; return end
 		local new_msgs = data.messages or {}
-		if #new_msgs == 0 then state.exhausted_forward = true; state.loading_newer = false; return end
+		if #new_msgs == 0 then
+			state.exhausted_forward = true
+			state.loading_newer = false
+			render()
+			return
+		end
 		local seen = {}
 		for _, m in ipairs(state.messages) do seen[tostring(m.id)] = true end
 		local newly_inserted = {}
@@ -1056,6 +1082,7 @@ function M.load_newer()
 				end
 			end
 			st.trim_oldest()
+				state.loading_newer = false
 			render()
 		end
 		state.loading_newer = false

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -606,6 +606,8 @@ function M.open_chat(chat_id, chat_title, chat_type)
 							server.view_messages(state.chat_id, last_read_id)
 							if last_read_id > (state.last_read_id or 0) then
 								state.last_read_id = last_read_id
+								state.saved_last_read = state.saved_last_read or {}
+								state.saved_last_read[state.chat_id] = last_read_id
 							end
 							if state.chat_id and state.groups[state.chat_id] then
 								state.groups[state.chat_id].unread_count = state.unread
@@ -826,7 +828,9 @@ function M.open_chat(chat_id, chat_title, chat_type)
 		if state.chat_id ~= cid then return end
 		if chat_info then
 			chat_info_holder = chat_info
-			state.last_read_id = chat_info.lastReadInboxMessageId or 0
+			local server_last = chat_info.lastReadInboxMessageId or 0
+			local local_last = state.saved_last_read and state.saved_last_read[cid] or 0
+			state.last_read_id = math.max(server_last, local_last)
 			if chat_info.onlineMemberCount and chat_info.onlineMemberCount > 0 then
 				state.online_count = chat_info.onlineMemberCount
 			end
@@ -881,7 +885,6 @@ function M.destroy_chat()
 	state._pending_edit = nil
 	state.msg_line_counts = {}
 	state.extra_before = {}
-	state.last_read_id = nil
 	state._unread_start = nil
 	state.loading = false
 	state.exhausted = false

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -591,27 +591,24 @@ function M.open_chat(chat_id, chat_title, chat_type)
 				end
 				local total_lines = vim.api.nvim_buf_line_count(state.buf)
 				if state.unread > 0 then
-					local current_idx = M.message_at_cursor()
-					if current_idx then
-						local last_read_id = nil
-						for i = 1, current_idx - 1 do
-							local m = state.messages[i]
-							if m._unread then
-								m._unread = nil
-								state.unread = math.max(0, state.unread - 1)
-								last_read_id = m.id
-							end
+					local cursor_line = vim.api.nvim_win_get_cursor(state.win)[1]
+					local off = title_offset()
+					local line = 1 + off
+					local last_read_id = nil
+					for i, m in ipairs(state.messages) do
+						line = line + (state.extra_before[i] or 0)
+						local n = state.msg_line_counts[i] or #fmt_msg(m)
+						if cursor_line >= line + n - 1 and m._unread then
+							m._unread = nil
+							state.unread = math.max(0, state.unread - 1)
+							last_read_id = m.id
 						end
-						if last_read_id then
-							server.view_messages(state.chat_id, last_read_id)
-							if last_read_id > (state.last_read_id or 0) then
-								state.last_read_id = last_read_id
-								state.saved_last_read = state.saved_last_read or {}
-								state.saved_last_read[state.chat_id] = last_read_id
-							end
-							if state.chat_id and state.groups[state.chat_id] then
-								state.groups[state.chat_id].unread_count = state.unread
-							end
+						line = line + n
+					end
+					if last_read_id then
+						server.view_messages(state.chat_id, last_read_id)
+						if state.chat_id and state.groups[state.chat_id] then
+							state.groups[state.chat_id].unread_count = state.unread
 						end
 					end
 				end
@@ -764,6 +761,16 @@ function M.open_chat(chat_id, chat_title, chat_type)
 			return first_unread_idx
 		end
 
+		local function set_cursor_to_idx(target_idx)
+			if not target_idx then return end
+			local l = line_of(state.messages[target_idx].id)
+			if not l then return end
+			if state.unread > 0 and state._unread_start == target_idx then
+				l = l + 1
+			end
+			pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
+		end
+
 		if pending == 0 then
 			title.update_title()
 			if saved_id then
@@ -782,8 +789,7 @@ function M.open_chat(chat_id, chat_title, chat_type)
 						render()
 						title.update_title()
 						local target_idx = first_unread_idx or #state.messages
-						local l = line_of(state.messages[target_idx].id)
-						if l then pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 }) end
+						set_cursor_to_idx(target_idx)
 					end
 				end)
 			elseif chat_info_holder and chat_info_holder.unreadCount
@@ -805,8 +811,7 @@ function M.open_chat(chat_id, chat_title, chat_type)
 						render()
 						title.update_title()
 						local target_idx = first_unread_idx or #state.messages
-						local l = line_of(state.messages[target_idx].id)
-						if l then pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 }) end
+						set_cursor_to_idx(target_idx)
 					end
 				end)
 			else
@@ -818,8 +823,7 @@ function M.open_chat(chat_id, chat_title, chat_type)
 					local first_unread_idx = count_unread()
 					render()
 					local target_idx = first_unread_idx or #state.messages
-					local l = line_of(state.messages[target_idx].id)
-					if l then pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 }) end
+					set_cursor_to_idx(target_idx)
 				end)
 			end
 		end
@@ -828,9 +832,9 @@ function M.open_chat(chat_id, chat_title, chat_type)
 		if state.chat_id ~= cid then return end
 		if chat_info then
 			chat_info_holder = chat_info
-			local server_last = chat_info.lastReadInboxMessageId or 0
-			local local_last = state.saved_last_read and state.saved_last_read[cid] or 0
-			state.last_read_id = math.max(server_last, local_last)
+			local from_server = chat_info.lastReadInboxMessageId or 0
+			local from_event = state.saved_last_read and state.saved_last_read[cid] or 0
+			state.last_read_id = math.max(from_server, from_event)
 			if chat_info.onlineMemberCount and chat_info.onlineMemberCount > 0 then
 				state.online_count = chat_info.onlineMemberCount
 			end

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -547,6 +547,10 @@ function M.open_chat(chat_id, chat_title, chat_type)
 								state.groups[state.chat_id].unread_count = 0
 								state.groups[state.chat_id].mention_count = 0
 							end
+							local latest = state.messages[#state.messages]
+							if latest then
+								server.view_messages(state.chat_id, latest.id)
+							end
 						end
 					end
 				end
@@ -892,31 +896,37 @@ function M.load_older()
 	state.loading = true
 	local chat_id = state.chat_id
 	local oldest = state.messages[1]
-	local cursor = vim.api.nvim_win_get_cursor(state.win)
-	local old_top = cursor[1]
+	local cursor_idx = M.message_at_cursor()
+	local cursor_msg_id = cursor_idx and state.messages[cursor_idx].id
+	local cursor_col = cursor_idx and vim.api.nvim_win_get_cursor(state.win)[2] or 0
 	server.get_messages_async(chat_id, server.DEFAULT_LIMIT, oldest.id, function(data)
 		if state.chat_id ~= chat_id then state.loading = false; return end
 		local new_msgs = data.messages or {}
 		if #new_msgs == 0 then state.exhausted = true; state.loading = false; return end
-		local new_lines = 0
+		local added = false
 		local seen = {}
 		for _, m in ipairs(state.messages) do seen[tostring(m.id)] = true end
 		for _, m in ipairs(new_msgs) do
 			if not seen[tostring(m.id)] then
 				seen[tostring(m.id)] = true
 				table.insert(state.messages, m)
-				new_lines = new_lines + #fmt_msg(m)
+				added = true
 			end
 		end
 		if state.chat_id ~= chat_id then state.loading = false; return end
-		if new_lines > 0 then
+		if added then
 			table.sort(state.messages, function(a, b)
 				if a.date ~= b.date then return a.date < b.date end
 				return a.id < b.id
 			end)
 			st.trim_newest()
 			render()
-			pcall(vim.api.nvim_win_set_cursor, state.win, { old_top + new_lines, cursor[2] })
+		end
+		if cursor_msg_id then
+			local restored_line = line_of(cursor_msg_id)
+			if restored_line then
+				pcall(vim.api.nvim_win_set_cursor, state.win, { restored_line, cursor_col })
+			end
 		end
 		state.loading = false
 	end, function() state.loading = false end, { before_date = oldest.date })

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -674,16 +674,93 @@ function M.open_chat(chat_id, chat_title, chat_type)
 	state.online_count = (cached and cached.online_count) or 0
 	state.permissions = {}
 	state.description = ""
+	local saved_id = state.saved_cursors and state.saved_cursors[cid]
+	local chat_info_holder = nil
 	local pending = 2
 	local function check_done()
 		pending = pending - 1
 		if pending == 0 then
 			title.update_title()
+			if saved_id then
+				state.messages = {}
+				state.exhausted = false
+				state.exhausted_forward = false
+				render()
+				server.get_messages_around_async(state.chat_id, saved_id, 31, function(data)
+					if state.chat_id == cid then
+						state.messages = data.messages or {}
+						table.sort(state.messages, function(a, b)
+							if a.date ~= b.date then return a.date < b.date end
+							return a.id < b.id
+						end)
+						render()
+						title.update_title()
+						if #state.messages > 0 then
+							server.view_messages(state.chat_id, state.messages[#state.messages].id)
+						end
+						local l = line_of(saved_id)
+						if l then
+							pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
+						else
+							M.jump_to_bottom()
+						end
+					end
+				end)
+			elseif chat_info_holder and chat_info_holder.unreadCount
+					and chat_info_holder.unreadCount > 0
+					and chat_info_holder.lastReadInboxMessageId
+					and chat_info_holder.lastReadInboxMessageId > 0 then
+				state.messages = {}
+				state.exhausted = false
+				state.exhausted_forward = false
+				render()
+				server.get_messages_around_async(state.chat_id, chat_info_holder.lastReadInboxMessageId, 31, function(data)
+					if state.chat_id == cid then
+						state.messages = data.messages or {}
+						table.sort(state.messages, function(a, b)
+							if a.date ~= b.date then return a.date < b.date end
+							return a.id < b.id
+						end)
+						render()
+						title.update_title()
+						if #state.messages > 0 then
+							server.view_messages(state.chat_id, state.messages[#state.messages].id)
+						end
+						local target = chat_info_holder.lastReadInboxMessageId
+						local scrolled = false
+						for i, m in ipairs(state.messages) do
+							if m.id == target then
+								local nxt = i + 1
+								if nxt <= #state.messages then
+									local l = line_of(state.messages[nxt].id)
+									if l then
+										pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
+										scrolled = true
+									end
+								end
+								break
+							end
+						end
+						if not scrolled then
+							M.jump_to_bottom()
+						end
+					end
+				end)
+			else
+				state.messages = {}
+				state.exhausted = false
+				state.exhausted_forward = false
+				render()
+				M.refresh_messages(function()
+					M.jump_to_bottom()
+				end)
+			end
 		end
 	end
 	server.get_chat_async(cid, function(chat_info)
 		if state.chat_id ~= cid then return end
 		if chat_info then
+			chat_info_holder = chat_info
 			if chat_info.onlineMemberCount and chat_info.onlineMemberCount > 0 then
 				state.online_count = chat_info.onlineMemberCount
 			end
@@ -701,42 +778,6 @@ function M.open_chat(chat_id, chat_title, chat_type)
 		end
 		check_done()
 	end)
-	local saved_id = state.saved_cursors and state.saved_cursors[cid]
-	if saved_id then
-		state.messages = {}
-		state.exhausted = false
-		state.exhausted_forward = false
-		render()
-		local cid = state.chat_id
-		server.get_messages_around_async(state.chat_id, saved_id, 31, function(data)
-			if state.chat_id == cid then
-				state.messages = data.messages or {}
-				table.sort(state.messages, function(a, b)
-					if a.date ~= b.date then return a.date < b.date end
-					return a.id < b.id
-				end)
-				render()
-				title.update_title()
-				if #state.messages > 0 then
-					server.view_messages(state.chat_id, state.messages[#state.messages].id)
-				end
-				local l = line_of(saved_id)
-				if l then
-					pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
-				else
-					M.jump_to_bottom()
-				end
-			end
-		end)
-	else
-		state.messages = {}
-		state.exhausted = false
-		state.exhausted_forward = false
-		render()
-		M.refresh_messages(function()
-			M.jump_to_bottom()
-		end)
-	end
 end
 
 function M.close_chat()
@@ -916,7 +957,7 @@ function M.refresh_messages(on_complete)
 	state.exhausted = false
 	state.exhausted_forward = false
 	local chat_id = state.chat_id
-	server.get_messages_async(chat_id, 10, nil, function(data)
+	server.get_messages_async(chat_id, 30, nil, function(data)
 		if state.chat_id ~= chat_id then return end
 		local raw = data.messages or {}
 		state.messages = {}

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -80,8 +80,11 @@ local function apply_highlights()
 		or "  \xE2\x97\x8F Forwarding"
 	local line = 1 + off
 	local line_counts = state.msg_line_counts
+	local prev_extra = 0
 	for i, m in ipairs(state.messages) do
-		line = line + (state.extra_before[i] or 0)
+		local extra = state.extra_before[i] or 0
+		line = line + (extra - prev_extra)
+		prev_extra = extra
 		local n = line_counts[i] or #fmt_msg(m)
 		if m.id == target_id then
 			local start_line = line - 1
@@ -595,10 +598,13 @@ function M.open_chat(chat_id, chat_title, chat_type)
 					local off = title_offset()
 					local line = 1 + off
 					local last_read_id = nil
+					local prev_extra = 0
 					for i, m in ipairs(state.messages) do
-						line = line + (state.extra_before[i] or 0)
+						local extra = state.extra_before[i] or 0
+						line = line + (extra - prev_extra)
+						prev_extra = extra
 						local n = state.msg_line_counts[i] or #fmt_msg(m)
-						if cursor_line >= line + n - 1 and m._unread then
+						if cursor_line >= line and m._unread then
 							m._unread = nil
 							state.unread = math.max(0, state.unread - 1)
 							last_read_id = m.id
@@ -610,7 +616,9 @@ function M.open_chat(chat_id, chat_title, chat_type)
 						if state.chat_id and state.groups[state.chat_id] then
 							state.groups[state.chat_id].unread_count = state.unread
 						end
-					end
+						title.update_title()
+						vim.cmd("redrawstatus")
+						end
 				end
 				if cursor_line == min_line and not state.exhausted and not state.loading then
 					M.load_older()
@@ -624,8 +632,11 @@ function M.open_chat(chat_id, chat_title, chat_type)
 					state._scroll_timer = nil
 				local line_counts = state.msg_line_counts
 				local l = min_line
+				local prev_extra = 0
 				for i, msg in ipairs(state.messages) do
-					l = l + (state.extra_before[i] or 0)
+					local extra = state.extra_before[i] or 0
+					l = l + (extra - prev_extra)
+					prev_extra = extra
 					local n = line_counts[i] or #fmt_msg(msg)
 						if cursor_line >= l and cursor_line < l + n then
 							state.saved_cursors = state.saved_cursors or {}
@@ -920,9 +931,11 @@ function M.message_at_cursor()
 	local off = title_offset()
 	local line_counts = state.msg_line_counts
 	local line = 1 + off
+	local prev_extra = 0
 	for idx, msg in ipairs(state.messages) do
 		local extra = state.extra_before[idx] or 0
-		line = line + extra
+		line = line + (extra - prev_extra)
+		prev_extra = extra
 		local n = line_counts[idx] or #fmt_msg(msg)
 		if cursor_line >= line and cursor_line < line + n then
 			return idx
@@ -1017,10 +1030,12 @@ function M.load_newer()
 		if #new_msgs == 0 then state.exhausted_forward = true; state.loading_newer = false; return end
 		local seen = {}
 		for _, m in ipairs(state.messages) do seen[tostring(m.id)] = true end
+		local newly_inserted = {}
 		for _, m in ipairs(new_msgs) do
 			if not seen[tostring(m.id)] then
 				seen[tostring(m.id)] = true
 				table.insert(state.messages, m)
+				table.insert(newly_inserted, m)
 			end
 		end
 		if #new_msgs > 0 then
@@ -1029,10 +1044,15 @@ function M.load_newer()
 				return a.id < b.id
 			end)
 			if state.last_read_id and state.last_read_id > 0 then
-				for _, m in ipairs(new_msgs) do
+				local new_unread = 0
+				for _, m in ipairs(newly_inserted) do
 					if m.id > state.last_read_id and not m.own then
 						m._unread = true
+						new_unread = new_unread + 1
 					end
+				end
+				if new_unread > 0 then
+					state.unread = state.unread + new_unread
 				end
 			end
 			st.trim_oldest()

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -604,6 +604,9 @@ function M.open_chat(chat_id, chat_title, chat_type)
 						end
 						if last_read_id then
 							server.view_messages(state.chat_id, last_read_id)
+							if last_read_id > (state.last_read_id or 0) then
+								state.last_read_id = last_read_id
+							end
 							if state.chat_id and state.groups[state.chat_id] then
 								state.groups[state.chat_id].unread_count = state.unread
 							end
@@ -741,7 +744,8 @@ function M.open_chat(chat_id, chat_title, chat_type)
 	local function check_done()
 		pending = pending - 1
 		local function count_unread()
-			local last_read = chat_info_holder and chat_info_holder.lastReadInboxMessageId or 0
+			local server_last = chat_info_holder and chat_info_holder.lastReadInboxMessageId or 0
+			local last_read = math.max(server_last, state.last_read_id or 0)
 			local unread_count = 0
 			local first_unread_idx
 			for i, m in ipairs(state.messages) do

--- a/lua/telegram/ui.lua
+++ b/lua/telegram/ui.lua
@@ -728,6 +728,22 @@ function M.open_chat(chat_id, chat_title, chat_type)
 	local pending = 2
 	local function check_done()
 		pending = pending - 1
+		local function position_at_first_unread()
+			local first_unread_idx = nil
+			local last_read = chat_info_holder and chat_info_holder.lastReadInboxMessageId or 0
+			local unread_count = 0
+			for i, m in ipairs(state.messages) do
+				if last_read > 0 and m.id > last_read then
+					unread_count = unread_count + 1
+					if not first_unread_idx then first_unread_idx = i end
+				end
+			end
+			state.unread = unread_count
+			local target_idx = first_unread_idx or #state.messages
+			local l = line_of(state.messages[target_idx].id)
+			if l then pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 }) end
+		end
+
 		if pending == 0 then
 			title.update_title()
 			if saved_id then
@@ -747,12 +763,7 @@ function M.open_chat(chat_id, chat_title, chat_type)
 						if #state.messages > 0 then
 							server.view_messages(state.chat_id, state.messages[#state.messages].id)
 						end
-						local l = line_of(saved_id)
-						if l then
-							pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
-						else
-							M.jump_to_bottom()
-						end
+						position_at_first_unread()
 					end
 				end)
 			elseif chat_info_holder and chat_info_holder.unreadCount
@@ -775,20 +786,7 @@ function M.open_chat(chat_id, chat_title, chat_type)
 						if #state.messages > 0 then
 							server.view_messages(state.chat_id, state.messages[#state.messages].id)
 						end
-						local target_id = chat_info_holder.lastReadInboxMessageId
-						local first_unread_idx = nil
-						for i, m in ipairs(state.messages) do
-							if m.id > target_id then
-								first_unread_idx = i
-								break
-							end
-						end
-						if first_unread_idx then
-							local l = line_of(state.messages[first_unread_idx].id)
-							if l then
-								pcall(vim.api.nvim_win_set_cursor, state.win, { l, 0 })
-							end
-						end
+						position_at_first_unread()
 					end
 				end)
 			else
@@ -797,7 +795,7 @@ function M.open_chat(chat_id, chat_title, chat_type)
 				state.exhausted_forward = false
 				render()
 				M.refresh_messages(function()
-					M.jump_to_bottom()
+					position_at_first_unread()
 				end)
 			end
 		end
@@ -811,7 +809,6 @@ function M.open_chat(chat_id, chat_title, chat_type)
 			end
 			state.description = chat_info.description or ""
 			state.default_restricted = chat_info.defaultRestricted or false
-			state.unread = chat_info.unreadCount or 0
 			groups.refresh_pinned_message(cid, chat_info.pinnedMessageId)
 		end
 		check_done()

--- a/src/client.ts
+++ b/src/client.ts
@@ -516,6 +516,7 @@ export class TelegramLSPClient {
       id: chat.id,
       title: chat.title,
       unreadCount: chat.unread_count || 0,
+      lastReadInboxMessageId: chat.last_read_inbox_message_id || 0,
       onlineMemberCount: chat.online_member_count || 0,
       memberCount,
       description,

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,7 @@ export interface RawTdChat {
   };
   unread_count?: number;
   unread_mention_count?: number;
+  last_read_inbox_message_id?: number;
   online_member_count?: number;
   last_message?: RawTdMessage | null;
   positions?: { list: { _: string }; order: string }[];


### PR DESCRIPTION
- **feat: align loading logic with Android behavior**
- **fix: maintain cursor position by message ID on older load, send read receipt on scroll past unread**
- **feat: add date separators and unread divider, fix cursor positioning with extra_before tracking**
- **fix: position cursor on first unread message after divider, sync state.unread from chat info**
- **fix: position cursor at first unread message instead of date group boundary**
- **fix: keep unread divider fixed at original position until all read, per-message read tracking**
- **fix: handle new-message unread correctly when at bottom, recalculate _unread on incremental load**
- **fix: protect unread counts from stale server responses, persist last_read_id locally**
- **fix: persist last_read_id per-chat like saved_cursors, prevent re-read on reopen**
- **fix: mark read only when cursor reaches last line of message, prevent spurious read tracking during page scroll**
- **fix: correct extra_before delta calc, immediate title/status update, dedup load_newer unread counting**
- **feat: add loading indicators and empty state to chat buffer, fix flag clearing order in callbacks**
- **chore(gitignore): add *.txt and *.py to ignored patterns**
